### PR TITLE
smoke_tests: wait for deployments availability

### DIFF
--- a/.github/workflows/gh-release-chart.yml
+++ b/.github/workflows/gh-release-chart.yml
@@ -38,6 +38,9 @@ jobs:
           helm template ./keda \
             -n keda \
             --set customManagedBy=kedify | kubectl apply --server-side --force-conflicts -f -
+          kubectl wait --timeout=300s --for=condition=Available deployment/keda-operator
+          kubectl wait --timeout=300s --for=condition=Available deployment/keda-admission-webhooks
+          kubectl wait --timeout=300s --for=condition=Available deployment/keda-operator-metrics-apiserver
           kubectl wait --timeout=300s -nkeda --for=condition=ready pod -lapp.kubernetes.io/name=keda-admission-webhooks
           kubectl wait --timeout=300s -nkeda --for=condition=ready pod -lapp.kubernetes.io/name=keda-operator-metrics-apiserver
           kubectl wait --timeout=300s -nkeda --for=condition=ready pod -lapp.kubernetes.io/name=keda-operator


### PR DESCRIPTION
check first `deployment` availability before checking `pod` readiness
```
validatingwebhookconfiguration.admissionregistration.k8s.io/keda-admission serverside-applied
error: no matching resources found
Error: Process completed with exit code 1.
```

https://github.com/kedify/charts/actions/runs/10196512985/job/28207435922