### PR TITLE
ci: refactor kedify chart release trigger

### DIFF
--- a/.github/workflows/gh-release-chart.yml
+++ b/.github/workflows/gh-release-chart.yml
@@ -4,15 +4,17 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "target version of either keda (~v2.14.2-1) or http-add-on (v0.8.0-1) helm chart"
+        description: "the workflow will figure out the correct chart version but optionally this can be overwritten here."
         required: false
-        default: 'v2.14.3-1'
+        default: ''
         type: string
-      keda:
-        description: "set this to false if you want to release http-add-on helm chart"
-        required: false
-        default: 'true'
-        type: string
+      chart:
+        description: "select the chart you want to release, either keda or http-add-on"
+        required: true
+        type: choice
+        options:
+          - keda
+          - http-add-on
 permissions:
   contents: read
 
@@ -32,7 +34,7 @@ jobs:
             --no-lb
             --k3s-arg "--disable=traefik,servicelb,local-storage@server:*"
       - name: Smoke test helm rendering and deployability (keda chart)
-        if: inputs.keda == 'true'
+        if: inputs.chart == 'keda'
         run: |
           kubectl create ns keda --dry-run=client -o yaml | kubectl apply -f -
           helm template ./keda \
@@ -48,7 +50,7 @@ jobs:
           kubectl get pods -A
 
       - name: Smoke test helm rendering and deployability (addon chart)
-        if: inputs.keda != 'true'
+        if: inputs.chart == 'http-add-on'
         run: |
           kubectl create ns keda --dry-run=client -o yaml | kubectl apply -f -
           # addon depends on ScaledObject CRD that is not part of the helm chart so we install also KEDA first
@@ -78,21 +80,28 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Add the -N suffix to chart's version (keda)
-        if: inputs.keda == 'true'
+      - name: Add the -N suffix to chart's version
         run: |
-          sed -i keda/Chart.yaml -e 's;^version:.*;version: ${{ inputs.version }};'
-      - name: Add the -N suffix to chart's version (addon)
-        if: inputs.keda != 'true'
-        run: |
-          sed -i http-add-on/Chart.yaml -e 's;^version:.*;version: ${{ inputs.version }};'
+          set -xeuo pipefail
+          version=${{ inputs.version }}
+          if [[ $version == "" ]]; then
+            name=$(cat ${{ inputs.chart }}/Chart.yaml | yq '.name')
+            last_versions=$(curl -s https://kedify.github.io/charts/index.yaml | \
+              yq '.entries.'"$name"'[].version | select( match("^v[0-9]+\.[0-9]+\.[0-9]+-[0-9]+$") )' | \
+              sed 's/-/./' \
+              sort -t "." -k1,1n -k2,2n -k3,3n -k4,4n | \
+              tail -n 1 | \
+              sed 's/\.\([0-9]\+\)$/-\1/')
+            version=$(echo "$last_version | awk -F'-' '{print $1 "-" $2+1}')
+          fi
+          sed -i ${{ inputs.chart }}/Chart.yaml -e 's;^version:.*;version: ${version};'
       - name: Publish Helm chart
         uses: stefanprodan/helm-gh-pages@master
         with:
           token: ${{ secrets.PAT_TOKEN }}
           charts_dir: "."
       - name: Create k3s cluster
-        if: inputs.keda == 'true'
+        if: inputs.chart == 'keda'
         uses: AbsaOSS/k3d-action@v2
         with:
           cluster-name: "test-cluster"
@@ -101,7 +110,7 @@ jobs:
             --no-lb
             --k3s-arg "--disable=traefik,servicelb,local-storage@server:*"
       - name: Smoke test helm installation
-        if: inputs.keda == 'true'
+        if: inputs.chart == 'keda'
         run: |
           # exp-backoff - we wait for pages to become available here
           for i in $(seq 16)


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->
This should make the chart release a bit more intuitive
* instead of setting `"true"` when releasing KEDA and `"false"` when releasing http-add-on, there is a select box to choose one or the other
* adding an option to leave the `version` input field blank to allow the pipeline to determine the latest released version of each chart and bump the suffix by 1, e.g. `v2.14.1-3` -> `v2.14.1-4`