### PR TITLE
http-add-on: attempt HTTP2 upgrade by default

### DIFF
--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -157,7 +157,7 @@ interceptor:
   # -- How often (in milliseconds) the interceptor does a full refresh of its endpoints cache. The interceptor will also use Kubernetes events to stay up-to-date with the endpoints cache changes. This duration is the maximum time it will take to see changes to the endpoints.
   endpointsCachePollingIntervalMS: 250
   # -- Whether or not the interceptor should force requests to use HTTP/2
-  forceHTTP2: false
+  forceHTTP2: true
   # -- The maximum number of idle connections allowed in the interceptor's in-memory connection pool. Set to 0 to indicate no limit
   maxIdleConns: 100
   # -- The timeout after which any idle connection is closed and removed from the interceptor's in-memory connection pool.


### PR DESCRIPTION
Enable attempts for HTTP2 upgrades on the interceptor, this is important for gRPC connections to work out of the box without the necessity to configure anything. Despite the name of the flag, this doesn't force HTTP2, it only configures HTTP transport to enable HTTP2 upgrades but still allows HTTP1.
https://github.com/golang/go/blob/f6c89abf897c4adf7dbd598029f0c12452b4ca25/src/net/http/transport.go#L291-L296

Users can still disable HTTP2 by setting `forceHTTP2: false`.