### PR TITLE
gh release chart: fix env var evaluation

### DIFF
--- a/.github/workflows/gh-release-chart.yml
+++ b/.github/workflows/gh-release-chart.yml
@@ -94,7 +94,7 @@ jobs:
               sed 's/\.\([0-9]\+\)$/-\1/')
             version=$(echo "$last_version" | awk -F'-' '{print $1 "-" $2+1}')
           fi
-          sed -i ${{ inputs.chart }}/Chart.yaml -e 's;^version:.*;version: ${version};'
+          sed -i ${{ inputs.chart }}/Chart.yaml -e "s;^version:.*;version: ${version};"
       - name: Publish Helm chart
         uses: stefanprodan/helm-gh-pages@master
         with:


### PR DESCRIPTION
accidentally broken in https://github.com/kedify/charts/pull/42, the `${{ .. }}` github vars get evaluated in single quotes but bash `${ }` doesn't.