### PR TITLE
http-add-on: metrics service

### DIFF
--- a/http-add-on/README.md
+++ b/http-add-on/README.md
@@ -156,6 +156,8 @@ their default values.
 | `interceptor.imagePullSecrets` | list | `[]` | The image pull secrets for the interceptor component |
 | `interceptor.keepAlive` | string | `"1s"` | The interceptor's connection keep alive timeout |
 | `interceptor.maxIdleConns` | int | `100` | The maximum number of idle connections allowed in the interceptor's in-memory connection pool. Set to 0 to indicate no limit |
+| `interceptor.metrics.port` | int | `2223` | The port to host metrics. |
+| `interceptor.metrics.service` | string | `"interceptor-metrics"` | The name of the Kubernetes `Service` for the metrics. |
 | `interceptor.nodeSelector` | object | `{}` | Node selector for pod scheduling ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/)) |
 | `interceptor.pdb.enabled` | bool | `true` | Whether to install the `PodDisruptionBudget` for the interceptor |
 | `interceptor.pdb.maxUnavailable` | int | `1` | The maximum number of replicas that can be unavailable for the interceptor |

--- a/http-add-on/templates/interceptor/service-metrics.yaml
+++ b/http-add-on/templates/interceptor/service-metrics.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.interceptor.metrics.service }}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:    
+    app.kubernetes.io/component: interceptor
+    {{- include "keda-http-add-on.labels" . | indent 4 }}
+  name: "{{ .Chart.Name }}-{{ .Values.interceptor.metrics.service }}"
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+  - name: metrics
+    port: {{ default 2223 .Values.interceptor.metrics.port }}
+    targetPort: {{ default 2223 .Values.interceptor.metrics.port }}
+  selector:
+    app.kubernetes.io/component: interceptor
+    {{- include "keda-http-add-on.matchLabels" . | indent 4 }}
+{{- end }}

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -134,6 +134,11 @@ interceptor:
     service: interceptor-proxy
     # -- The port on which the interceptor's proxy service will listen for live HTTP traffic
     port: 8080
+  metrics:
+    # -- The name of the Kubernetes `Service` for the metrics.
+    service: interceptor-metrics
+    # -- The port to host metrics.
+    port: 2223
   replicas:
     # -- The minimum number of interceptor replicas that should ever be running
     min: 3


### PR DESCRIPTION
followup to https://github.com/kedify/charts/pull/46, there is also [metrics service](https://github.com/kedacore/http-add-on/blob/08c811fe205daaf2bc55c6a46155be2729f21916/config/interceptor/metrics.service.yaml#L1-L11) necessary for the e2e tests