### PR TITLE
http-add-on: disable interceptor pdb

### DIFF
--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -219,7 +219,7 @@ interceptor:
   # configuration of pdb for the interceptor
   pdb:
     # -- Whether to install the `PodDisruptionBudget` for the interceptor
-    enabled: true
+    enabled: false
     # -- The minimum number of replicas that should be available for the interceptor
     minAvailable: 0
     # -- The maximum number of replicas that can be unavailable for the interceptor


### PR DESCRIPTION
Kedify agent doesn't have RBAC to install PDB so disabling this by default.
```
10-01 10:39:54	ERROR	Reconciler error	{"controller": "kedifyconfiguration", "controllerGroup": "install.kedify.io", "controllerKind": "KedifyConfiguration", "KedifyConfiguration": {"name":"kedify","namespace":"keda"}, "namespace": "keda", "name": "kedify", "reconcileID": "29acc29d-ceda-4cad-8257-e4c0d4ae5319", "error": "error while reconciling KEDA installation: failed to install KEDA http addon: failed to create object: poddisruptionbudgets.policy is forbidden: User \"system:serviceaccount:keda:kedify-agent\" cannot create resource \"poddisruptionbudgets\" in API group \"policy\" in the namespace \"keda\""}
```