### PR TITLE
http-add-on: RBAC to emit events

### DIFF
--- a/http-add-on/templates/interceptor/rbac.yml
+++ b/http-add-on/templates/interceptor/rbac.yml
@@ -24,6 +24,12 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Adding the same RBAC for `Events` that keda-operator already has to the http-add-on interceptor.
https://github.com/kedify/charts/blob/2f59e10033b4b99bf33164816875d20b43a28a13/keda/templates/manager/clusterrole.yaml#L27-L32