### PR TITLE
kedify-agent: disable istio sidecar injection for CR and CRD creating jobs

### DIFF
--- a/kedify-agent/templates/cr-install/cr-job.yaml
+++ b/kedify-agent/templates/cr-install/cr-job.yaml
@@ -15,6 +15,8 @@ spec:
   backoffLimit: 4
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: create-default-kedifyconfig
     spec:

--- a/kedify-agent/templates/crd-install/crd-job.yaml
+++ b/kedify-agent/templates/crd-install/crd-job.yaml
@@ -15,6 +15,8 @@ spec:
   ttlSecondsAfterFinished: 43200 # 12h
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app.kubernetes.io/component: {{ include "crdInstall" . | quote }}
     spec:


### PR DESCRIPTION
with istio sidecar, the job has issues
1) the sidecar must be fully operational in order to allow calls to kube-apiservice - we could fix this by adding retry logic
2) the sidecar doesn't terminate by itself - https://github.com/istio/istio/issues/6324 - we would need to add logic to explicit terminate the istio container if it's injected

given these are non-trivial workarounds with potential for issues, and the jobs only create CRD and then CR, I'd like to propose to rather disable istio injection.

closes: https://github.com/kedify/charts/issues/59