### PR TITLE
agent: add missing prp RBAC for crd install job

### DIFF
--- a/kedify-agent/templates/crd-install/crd-rbac.yaml
+++ b/kedify-agent/templates/crd-install/crd-rbac.yaml
@@ -36,6 +36,7 @@ rules:
   resourceNames:
   - kedifyconfigurations.install.kedify.io
   - scalingpolicies.keda.kedify.io
+  - podresourceprofiles.keda.kedify.io
 - apiGroups:
   - apiextensions.k8s.io
   resources:


### PR DESCRIPTION
https://github.com/kedify/charts/pull/61 introduces new CRD but the RBAC won't allow installing it
```
$ k logs kedify-agent-crd-install-jxxqs
+ set -o nounset
+ kubectl apply -f /data/
customresourcedefinition.apiextensions.k8s.io/kedifyconfigurations.install.kedify.io unchanged
customresourcedefinition.apiextensions.k8s.io/scalingpolicies.keda.kedify.io unchanged
Error from server (Forbidden): error when retrieving current configuration of:
Resource: "apiextensions.k8s.io/v1, Resource=customresourcedefinitions", GroupVersionKind: "apiextensions.k8s.io/v1, Kind=CustomResourceDefinition"
Name: "podresourceprofiles.keda.kedify.io", Namespace: ""
from server for: "/data/kedify-podresourceprofile.yaml": customresourcedefinitions.apiextensions.k8s.io "podresourceprofiles.keda.kedify.io" is forbidden: User "system:serviceaccount:keda:kedify-agent-crd-install" cannot get resource "customresourcedefinitions" in API group "apiextensions.k8s.io" at the cluster scope
```