### PR TITLE
Add a way to change the METRICS_WATCH_NAMESPACE which further restric…

### DIFF
--- a/kedify-agent/templates/agent-deployment.yaml
+++ b/kedify-agent/templates/agent-deployment.yaml
@@ -61,6 +61,8 @@ spec:
             - name: PRP_REQUIRES_ANNOTATED_PODS
               value: {{ .Values.agent.features.prpRequiresAnnotatedPods | quote }}
             {{- end }}
+            - name: METRICS_WATCH_NAMESPACE
+              value: {{ .Values.agent.metricsWatchNamespace | quote }}
             - name: RBAC_READ_NODES
               value: {{ .Values.agent.rbac.readNodes | quote }}
             - name: RBAC_READ_PODS

--- a/kedify-agent/values.yaml
+++ b/kedify-agent/values.yaml
@@ -24,6 +24,9 @@ agent:
     pullPolicy: IfNotPresent
   imagePullSecrets: []
 
+  # comma-separated list of namespaces where pod utilization metrics should be collected
+  # or if unset denotes all namespaces, the collecting itself needs to be also enabled by KubernetesMetricsScraping flag
+  metricsWatchNamespace: ""
   # if anything else than 'false', the log will not print the ascii logo
   noBanner: false
   # if anything else than 'false', the log will not contain colors


### PR DESCRIPTION
note: comma must be escaped when passing the values using `--set` (if it's in the value file, normal unescaped comma works)

```
helm template ./kedify-agent -nkeda \
           --set agent.apiKey=kfy_facefaceface424242d0f7e1963c7d542aee42424242424242424242424242420  \
           --set agent.orgId=42424242-42ab-42ab-42ab-424242424242 \
           --set agent.metricsWatchNamespace="a\,b\,c" | grep -A1 METRICS_WATCH_NAMESPACE
            - name: METRICS_WATCH_NAMESPACE
              value: "a,b,c"
```