### PR TITLE
agent: configurable kedify-proxy log format

### DIFF
--- a/kedify-agent/templates/agent-deployment.yaml
+++ b/kedify-agent/templates/agent-deployment.yaml
@@ -43,6 +43,10 @@ spec:
                 secretKeyRef:
                   name: kedify-agent
                   key: apikey
+            {{- if .Values.agent.kedifyProxyLogFormat }}
+            - name: KEDIFY_PROXY_LOG_FORMAT
+              value: {{ .Values.agent.kedifyProxyLogFormat | quote }}
+            {{- end }}
             - name: HELM_REPOSITORY_CONFIG
               value: /helm/repository/repositories.yaml
             - name: HELM_REPOSITORY_CACHE

--- a/kedify-agent/values.yaml
+++ b/kedify-agent/values.yaml
@@ -14,6 +14,9 @@ agent:
   # which corresponds to custom debug levels of increasing verbosity
   logLevel: info
 
+  # Log format for kedify-proxy
+  # kedifyProxyLogFormat: json
+
   # should the KedifyConfiguration and ScalingPolicy CRDs be also part of the release
   createCrds: true
   createKedifyConfiguration: true


### PR DESCRIPTION
default is the original envoy log format
```
[2024-11-12 10:20:00.993][1][info][main] [source/server/server.cc:426] initializing epoch 0 (base id=0, hot restart version=11.104)
[2024-11-12 10:20:00.993][1][info][main] [source/server/server.cc:428] statically linked extensions:
[2024-11-12 10:20:00.993][1][info][main] [source/server/server.cc:430]   envoy.http.custom_response: envoy.extensions.http.custom_response.local_response_policy, envoy.extensions.http.custom_response.redirect_policy
[2024-11-12 10:20:00.993][1][info][main] [source/server/server.cc:430]   envoy.dubbo_proxy.serializers: dubbo.hessian2
[2024-11-12 10:20:00.993][1][info][main] [source/server/server.cc:430]   envoy.matching.network.input: envoy.matching.inputs.application_protocol, envoy.matching.inputs.destination_ip, envoy.matching.inputs.destination_port, envoy.matching.inputs.direct_source_ip, envoy.matching.inputs.dns_san, envoy.matching.inputs.filter_state, envoy.matching.inputs.server_name, envoy.matching.inputs.source_ip, envoy.matching.inputs.source_port, envoy.matching.inputs.source_type, envoy.matching.inputs.subject, envoy.matching.inputs.transport_protocol, envoy.matching.inputs.uri_san
[2024-11-12 10:20:00.993][1][info][main] [source/server/server.cc:430]   envoy.filters.http.upstream: envoy.buffer, envoy.ext_proc, envoy.filters.http.admission_control, envoy.filters.http.aws_lambda, envoy.filters.http.aws_request_signing, envoy.filters.http.buffer, envoy.filters.http.composite, envoy.filters.http.ext_proc, envoy.filters.http.header_mutation, envoy.filters.http.match_delegate, envoy.filters.http.upstream_codec, envoy.filters.http.wasm
[2024-11-12 10:20:00.993][1][info][main] [source/server/server.cc:430]   envoy.rds_factory: envoy.rds_factory.default
[2024-11-12 10:20:00.993][1][info][main] [source/server/server.cc:430]   envoy.compression.decompressor: envoy.compression.brotli.decompressor, envoy.compression.gzip.decompressor, envoy.compression.zstd.decompressor
[2024-11-12 10:20:00.994][1][info][main] [source/server/server.cc:430]   envoy.filters.http: envoy.bandwidth_limit, envoy.buffer, envoy.cors, envoy.csrf, envoy.ext_authz, envoy.ext_proc, envoy.fault, envoy.filters.http.adaptive_concurrency, envoy.filters.http.admission_control, envoy.filters.http.alternate_protocols_cache, envoy.filters.http.aws_lambda, envoy.filters.http.aws_request_signing, envoy.filters.http.bandwidth_limit, envoy.filters.http.basic_auth, envoy.filters.http.buffer, envoy.filters.http.cache, envoy.filters.http.cdn_loop, envoy.filters.http.composite, envoy.filters.http.compressor, envoy.filters.http.connect_grpc_bridge, envoy.filters.http.cors, envoy.filters.http.credential_injector, envoy.filters.http.csrf, envoy.filters.http.custom_response, envoy.filters.http.decompressor, envoy.filters.http.dynamic_forward_proxy, envoy.filters.http.ext_authz, envoy.filters.http.ext_proc, envoy.filters.http.fault, envoy.filters.http.file_system_buffer, envoy.filters.http.gcp_authn, envoy.filters.http.geoip, envoy.filters.http.grpc_field_extraction, envoy.filters.http.grpc_http1_bridge, envoy.filters.http.grpc_http1_reverse_bridge, envoy.filters.http.grpc_json_transcoder, envoy.filters.http.grpc_stats, envoy.filters.http.grpc_web, envoy.filters.http.header_mutation, envoy.filters.http.header_to_metadata, envoy.filters.http.health_check, envoy.filters.http.ip_tagging, envoy.filters.http.json_to_metadata, envoy.filters.http.jwt_authn, envoy.filters.http.local_ratelimit, envoy.filters.http.lua, envoy.filters.http.match_delegate, envoy.filters.http.oauth2, envoy.filters.http.on_demand, envoy.filters.http.original_src, envoy.filters.http.proto_message_extraction, envoy.filters.http.rate_limit_quota, envoy.filters.http.ratelimit, envoy.filters.http.rbac, envoy.filters.http.router, envoy.filters.http.set_filter_state, envoy.filters.http.set_metadata, envoy.filters.http.stateful_session, envoy.filters.http.tap, envoy.filters.http.thrift_to_metadata, envoy.filters.http.wasm, envoy.geoip, envoy.grpc_http1_bridge, envoy.grpc_json_transcoder, envoy.grpc_web, envoy.health_check, envoy.ip_tagging, envoy.local_rate_limit, envoy.lua, envoy.rate_limit, envoy.router
[2024-11-12 10:20:00.994][1][info][main] [source/server/server.cc:430]   envoy.http.header_validators: envoy.http.header_validators.envoy_default
```

can be configured via env var `KEDIFY_PROXY_LOG_FORMAT=json`
```
{"Timestamp":"2024-11-12T11:16:45.885523000","ThreadId":"1","SourceLine":"server.cc:426","Level":"info","Message":"initializing epoch 0 (base id=0, hot restart version=11.104)"}
{"Timestamp":"2024-11-12T11:16:45.885554000","ThreadId":"1","SourceLine":"server.cc:428","Level":"info","Message":"statically linked extensions:"}
{"Timestamp":"2024-11-12T11:16:45.885558000","ThreadId":"1","SourceLine":"server.cc:430","Level":"info","Message":"  envoy.path.match: envoy.path.match.uri_template.uri_template_matcher"}
{"Timestamp":"2024-11-12T11:16:45.885562000","ThreadId":"1","SourceLine":"server.cc:430","Level":"info","Message":"  envoy.route.early_data_policy: envoy.route.early_data_policy.default"}
{"Timestamp":"2024-11-12T11:16:45.885566000","ThreadId":"1","SourceLine":"server.cc:430","Level":"info","Message":"  envoy.tracers: envoy.tracers.datadog, envoy.tracers.opencensus, envoy.tracers.opentelemetry, envoy.tracers.skywalking, envoy.tracers.xray, envoy.tracers.zipkin, envoy.zipkin"}
{"Timestamp":"2024-11-12T11:16:45.885570000","ThreadId":"1","SourceLine":"server.cc:430","Level":"info","Message":"  envoy.http.early_header_mutation: envoy.http.early_header_mutation.header_mutation"}
{"Timestamp":"2024-11-12T11:16:45.885574000","ThreadId":"1","SourceLine":"server.cc:430","Level":"info","Message":"  envoy.quic.connection_id_generator: envoy.quic.deterministic_connection_id_generator"}
{"Timestamp":"2024-11-12T11:16:45.885578000","ThreadId":"1","SourceLine":"server.cc:430","Level":"info","Message":"  envoy.clusters: envoy.cluster.eds, envoy.cluster.logical_dns, envoy.cluster.original_dst, envoy.cluster.static, envoy.cluster.strict_dns, envoy.clusters.aggregate, envoy.clusters.dynamic_forward_proxy, envoy.clusters.redis"}
{"Timestamp":"2024-11-12T11:16:45.885582000","ThreadId":"1","SourceLine":"server.cc:430","Level":"info","Message":"  envoy.health_check.event_sinks: envoy.health_check.event_sink.file"}
{"Timestamp":"2024-11-12T11:16:45.885585000","ThreadId":"1","SourceLine":"server.cc:430","Level":"info","Message":"  envoy.http.original_ip_detection: envoy.http.original_ip_detection.custom_header, envoy.http.original_ip_detection.xff"}
```