### PR TITLE
agent: fix addons subchart install condition name

### DIFF
--- a/kedify-agent/Chart.yaml
+++ b/kedify-agent/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
   - name: keda-add-ons-http
     repository: https://kedify.github.io/charts
     version: v0.8.1-1
-    condition: kedaAddOnsHttp.enabled
+    condition: kedaAddOnsHttp.enabled,keda-add-ons-http.enabled
 home: https://github.com/kedify/charts
 sources:
   - https://github.com/kedify/agent

--- a/kedify-agent/templates/NOTES.txt
+++ b/kedify-agent/templates/NOTES.txt
@@ -12,6 +12,6 @@ You have successfully installed the:
 {{- if .Values.keda.enabled }}
  - keda
 {{- end}}
-{{- if .Values.kedaAddOnsHttp.enabled }}
+{{- if (or (and .Values.kedaAddOnsHttp .Values.kedaAddOnsHttp.enabled) (and (index .Values "keda-add-ons-http") (index .Values "keda-add-ons-http").enabled)) }}
  - keda-add-ons-http
 {{- end}}

--- a/kedify-agent/templates/agent-deployment.yaml
+++ b/kedify-agent/templates/agent-deployment.yaml
@@ -3,7 +3,6 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/component: manager
-    app.kubernetes.io/instance: kedify-agent
     control-plane: kedify-agent
     {{- include "kedify-agent.labels" . | nindent 4 }}
   name: kedify-agent

--- a/kedify-agent/values.yaml
+++ b/kedify-agent/values.yaml
@@ -112,6 +112,6 @@ keda:
   # for all available values, check: https://github.com/kedify/charts/blob/main/keda/values.yaml
   enabled: false
 
-kedaAddOnsHttp:
+keda-add-ons-http:
   # for all available values, check: https://github.com/kedify/charts/blob/main/http-add-on/values.yaml
   enabled: false


### PR DESCRIPTION
the preferred form of condition enablement for subchart is by the chart name
https://helm.sh/docs/chart_best_practices/dependencies/#conditions-and-tags

By default, addon chart is disabled and for backwards compatibility, both of these options are supported
```yaml
kedaAddOnsHttp:
  enabled: true

keda-add-ons-http:
  enabled: true
```