### PR TITLE
allow setting custom env vars for scaler

### DIFF
--- a/http-add-on/templates/scaler/deployment.yaml
+++ b/http-add-on/templates/scaler/deployment.yaml
@@ -54,6 +54,10 @@ spec:
           value: "{{ default 9091 .Values.interceptor.admin.port }}"
         - name: KEDA_HTTP_SCALER_STREAM_INTERVAL_MS
           value: "{{ .Values.scaler.streamInterval }}"
+        {{- range .Values.scaler.additionalEnvVars }}
+        - name: "{{ .name }}"
+          value: "{{ .value }}"
+        {{- end }}
         resources:
           {{- toYaml .Values.scaler.resources | nindent 10 }}
         livenessProbe:


### PR DESCRIPTION
The kedify http-add-on contains more configuration knobs through env variables.
