### PR TITLE
http addon: increase default memory limits

### DIFF
--- a/http-add-on/Chart.yaml
+++ b/http-add-on/Chart.yaml
@@ -16,7 +16,7 @@ version: v0.8.1-2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: v0.8.1-8
+appVersion: v0.8.1-9
 home: https://github.com/kedacore/http-add-on
 sources:
   - https://github.com/kedacore/http-add-on

--- a/http-add-on/Chart.yaml
+++ b/http-add-on/Chart.yaml
@@ -11,12 +11,12 @@ kubeVersion: ">=v1.23.0-0"
 # to the chart and its templates, including the app version. This is incremented at chart release time and does not need
 # to be included in any PRs to main.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v0.8.1-1
+version: v0.8.1-2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: v0.8.1-7
+appVersion: v0.8.1-8
 home: https://github.com/kedacore/http-add-on
 sources:
   - https://github.com/kedacore/http-add-on

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -235,7 +235,7 @@ images:
   # the build for the latest commit to the `main` branch,
   # and you can target any other commit with `sha-<GIT_SHA[0:7]>`
   # -- Image tag for the http add on. This tag is applied to the images listed in `images.operator`, `images.interceptor`, and `images.scaler`. Optional, given app version of Helm chart is used by default
-  tag: v0.8.1-8
+  tag: v0.8.1-9
   # -- Image name for the operator image component
   operator: ghcr.io/kedify/http-add-on-operator
   # -- Image name for the interceptor image component

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -106,7 +106,7 @@ scaler:
   resources:
     limits:
       cpu: 0.5
-      memory: 64Mi
+      memory: 512Mi
     requests:
       cpu: 250m
       memory: 20Mi
@@ -184,7 +184,7 @@ interceptor:
     # -- The CPU/memory resource limit for the operator component
     limits:
       cpu: 0.5
-      memory: 64Mi
+      memory: 512Mi
     # -- The CPU/memory resource request for the operator component
     requests:
       cpu: 250m
@@ -235,7 +235,7 @@ images:
   # the build for the latest commit to the `main` branch,
   # and you can target any other commit with `sha-<GIT_SHA[0:7]>`
   # -- Image tag for the http add on. This tag is applied to the images listed in `images.operator`, `images.interceptor`, and `images.scaler`. Optional, given app version of Helm chart is used by default
-  tag: v0.8.1-7
+  tag: v0.8.1-8
   # -- Image name for the operator image component
   operator: ghcr.io/kedify/http-add-on-operator
   # -- Image name for the interceptor image component

--- a/kedify-agent/Chart.yaml
+++ b/kedify-agent/Chart.yaml
@@ -3,8 +3,8 @@ name: kedify-agent
 description: Kedify agent - Helm Chart
 kubeVersion: ">=v1.23.0-0"
 type: application
-version: "v0.0.5"
-appVersion: "v0.1.4"
+version: "v0.0.6"
+appVersion: "v0.1.5"
 icon: https://github.com/kedify/marketing/raw/refs/heads/main/public/assets/images/logo.svg
 dependencies:
   - name: keda
@@ -13,7 +13,7 @@ dependencies:
     condition: keda.enabled
   - name: keda-add-ons-http
     repository: https://kedify.github.io/charts
-    version: v0.8.1-1
+    version: v0.8.1-2
     condition: kedaAddOnsHttp.enabled,keda-add-ons-http.enabled
 home: https://github.com/kedify/charts
 sources:

--- a/kedify-agent/values.yaml
+++ b/kedify-agent/values.yaml
@@ -26,7 +26,7 @@ agent:
   createKedifyConfiguration: true
 
   image:
-    tag: "v0.1.4"
+    tag: "v0.1.5"
     repository: ghcr.io/kedify/agent
     pullPolicy: IfNotPresent
   imagePullSecrets: []


### PR DESCRIPTION
the default limits are not sufficient even for clusters with 100 `HTTPScaledObjects`.

also bumping the agent chart as the addon is a dependency there.