### PR TITLE
ci: run tests on kind 1.31 and 1.30

### DIFF
--- a/.github/workflows/ci-http-add-on.yml
+++ b/.github/workflows/ci-http-add-on.yml
@@ -40,16 +40,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetesVersion: [v1.29, v1.28, v1.27, v1.26]
+        kubernetesVersion: [v1.31, v1.30]
         include:
-          - kubernetesVersion: v1.29
-            kindImage: kindest/node:v1.29.0@sha256:eaa1450915475849a73a9227b8f201df25e55e268e5d619312131292e324d570
-          - kubernetesVersion: v1.28
-            kindImage: kindest/node:v1.28.0@sha256:b7a4cad12c197af3ba43202d3efe03246b3f0793f162afb40a33c923952d5b31
-          - kubernetesVersion: v1.27
-            kindImage: kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72
-          - kubernetesVersion: v1.26
-            kindImage: kindest/node:v1.26.6@sha256:6e2d8b28a5b601defe327b98bd1c2d1930b49e5d8c512e1895099e4504007adb
+          - kubernetesVersion: v1.31
+            kindImage: kindest/node:v1.31.2
+          - kubernetesVersion: v1.30
+            kindImage: kindest/node:v1.30.6
     steps:
       - name: Check out code
         uses: actions/checkout@v2


### PR DESCRIPTION
previously this was running on 1.26 - 1.29 which is a bit dated