### PR TITLE
agent: fix node and status reporting

### DIFF
--- a/kedify-agent/Chart.yaml
+++ b/kedify-agent/Chart.yaml
@@ -3,8 +3,8 @@ name: kedify-agent
 description: Kedify agent - Helm Chart
 kubeVersion: ">=v1.23.0-0"
 type: application
-version: "v0.0.7"
-appVersion: "v0.1.5"
+version: "v0.0.8"
+appVersion: "v0.1.8"
 icon: https://github.com/kedify/marketing/raw/refs/heads/main/public/assets/images/logo.svg
 dependencies:
   - name: keda

--- a/kedify-agent/Chart.yaml
+++ b/kedify-agent/Chart.yaml
@@ -4,7 +4,7 @@ description: Kedify agent - Helm Chart
 kubeVersion: ">=v1.23.0-0"
 type: application
 version: "v0.0.8"
-appVersion: "v0.1.8"
+appVersion: "v0.1.9"
 icon: https://github.com/kedify/marketing/raw/refs/heads/main/public/assets/images/logo.svg
 dependencies:
   - name: keda

--- a/kedify-agent/templates/cr-install/cr-configmap.yaml
+++ b/kedify-agent/templates/cr-install/cr-configmap.yaml
@@ -18,7 +18,9 @@ data:
     spec:
       clusterName: {{ .Values.clusterName }}
       kedaInstallations:
-      - httpAddonHelm:
+      - agentAutoUpdate: false
+        name: keda
+        httpAddonHelm:
           enabled: true
           values: |-
             ---

--- a/kedify-agent/values.yaml
+++ b/kedify-agent/values.yaml
@@ -41,7 +41,7 @@ agent:
         disabled: true
 
   image:
-    tag: "v0.1.8"
+    tag: "v0.1.9"
     repository: ghcr.io/kedify/agent
     pullPolicy: IfNotPresent
   imagePullSecrets: []

--- a/kedify-agent/values.yaml
+++ b/kedify-agent/values.yaml
@@ -41,7 +41,7 @@ agent:
         disabled: true
 
   image:
-    tag: "v0.1.7"
+    tag: "v0.1.8"
     repository: ghcr.io/kedify/agent
     pullPolicy: IfNotPresent
   imagePullSecrets: []


### PR DESCRIPTION
fixes:
* bumping agent to v0.1.9 for node reporting
* reverting part of https://github.com/kedify/charts/pull/73, adding back `name` for keda installation as this is used in the status reporting.
