### PR TITLE
ci: automated milestones tracker for kedify-agent chart

### DIFF
--- a/.github/workflows/milestones-tracker.yaml
+++ b/.github/workflows/milestones-tracker.yaml
@@ -1,0 +1,49 @@
+name: Milestones Tracker
+
+on:
+  pull_request:
+    types: [closed]
+    paths:
+      - kedify-agent/**
+
+jobs:
+  milestone_tracker:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Ensure correct milestone
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          has_milestone=$(gh pr view -R kedify/charts ${PR_NUMBER} --json 'milestone' --jq '.milestone.title | length')
+          if [[ "$has_milestone" == 0 ]]; then
+              echo "setting 'kedify-agent/next' milestone for PR #${PR_NUMBER}"
+              gh pr edit -R kedify/charts ${PR_NUMBER} --milestone "kedify-agent/next"
+              exit 0
+          fi
+          labels=( $(gh pr view -R kedify/charts ${PR_NUMBER} --json 'labels' --jq '.labels[].name') )
+          for label in "${labels[@]}"; do
+              if [[ "$label" == "release/kedify-agent" ]]; then
+                  has_release_label="true"
+              fi
+          done
+
+          if [[ "$has_release_label" != "true" ]]; then
+              echo "not a release PR #${PR_NUMBER}, labels: ${labels[*]}"
+          fi
+          milestone=$(gh pr view -R kedify/charts ${PR_NUMBER} --json 'milestone' --jq '.milestone.title')
+          echo "release PR #${PR_NUMBER} with milestone: $milestone"
+          next_milestone_prs=( $(gh pr list -R kedify/charts --search "milestone:kedify-agent/next" --state merged --json number --jq '.[].number') )
+          for pr in "${next_milestone_prs[@]}"; do
+              echo "moving PR #$pr milestone 'kedify-agent/next' => '$milestone'"
+              gh pr edit -R kedify/charts "$pr" --milestone "$milestone"
+          done
+          release_tag=${milestone#*/}
+          pr_body="$(gh pr view $PR_NUMBER --json 'body' --jq '.body')" 
+
+          echo "creating release $milestone"
+          gh release create -R kedify/charts "$milestone" --latest --title "kedify-agent: $release_tag" --notes "${pr_body}"

--- a/.github/workflows/publish-chart-from-release.yaml
+++ b/.github/workflows/publish-chart-from-release.yaml
@@ -1,0 +1,19 @@
+name: Publish kedify-agent chart from release
+
+on:
+  push:
+    tags:
+      - 'kedify-agent/v*.*.*'
+
+jobs:
+  publish-chart:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Publish Helm chart
+        uses: stefanprodan/helm-gh-pages@master
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
+          linting: "off"
+          dependencies: "kedify,https://kedify.github.io/charts"
+          charts_dir: "."


### PR DESCRIPTION
Because this repository `main` branch rebases nightly on the upstream, there is no way to track commits between releases, branches and tags. I would like to propose using github milestones for release tracking.

* when a PR affecting `kedify-agent` chart merges, it will get assigned `kedify-agent/next` milestone 
* when a release PR with label `release/kedify-agent` and milestone `kedify-agent/vX.Y.Z` is merged
  * all PRs in `kedify-agent/next` will be moved into a `kedify-agent/vX.Y.Z` release milestone
  * release `vX.Y.Z` will be generated with release notes aggregating both kedify-agent image CHANGELOG and chart CHANGELOG
  * with release published, github will create also a matching tag `kedify-agent/vX.Y.Z`
    * tag creation will trigger helm chart publish action publishing `kedify-agent` chart into `gh-pages` branch