### PR TITLE
keda: default images based on 2.16.1 upstream release

### DIFF
--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -14,21 +14,21 @@ image:
     # -- Image name of KEDA operator
     repository: kedify/keda-operator
     # -- Image tag of KEDA operator. Optional, given app version of Helm chart is used by default
-    tag: "v2.16.0-1"
+    tag: "v2.16.1-0"
   metricsApiServer:
     # -- Image registry of KEDA Metrics API Server
     registry: ghcr.io
     # -- Image name of KEDA Metrics API Server
     repository: kedify/keda-metrics-apiserver
     # -- Image tag of KEDA Metrics API Server. Optional, given app version of Helm chart is used by default
-    tag: "v2.16.0-1"
+    tag: "v2.16.1-0"
   webhooks:
     # -- Image registry of KEDA admission-webhooks
     registry: ghcr.io
     # -- Image name of KEDA admission-webhooks
     repository: kedify/keda-admission-webhooks
     # -- Image tag of KEDA admission-webhooks . Optional, given app version of Helm chart is used by default
-    tag: "v2.16.0-1"
+    tag: "v2.16.1-0"
   # -- Image pullPolicy for all KEDA components
   pullPolicy: Always
 


### PR DESCRIPTION
Upstream KEDA 2.16.1 has been released
- https://github.com/kedacore/charts/releases/tag/v2.16.1
- https://github.com/kedacore/keda/releases/tag/v2.16.1

This PR prepares for kedify/keda chart release with Kedify-flavoured images based on the latest release.

