### PR TITLE
addon: default images based on 0.9.0 upstream release

### DIFF
--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -235,7 +235,7 @@ images:
   # the build for the latest commit to the `main` branch,
   # and you can target any other commit with `sha-<GIT_SHA[0:7]>`
   # -- Image tag for the http add on. This tag is applied to the images listed in `images.operator`, `images.interceptor`, and `images.scaler`. Optional, given app version of Helm chart is used by default
-  tag: v0.8.2-1
+  tag: v0.9.0-0
   # -- Image name for the operator image component
   operator: ghcr.io/kedify/http-add-on-operator
   # -- Image name for the interceptor image component


### PR DESCRIPTION
Upstream http-add-on 0.9.0 has been released

* https://github.com/kedacore/charts/releases/tag/keda-add-ons-http-v0.9.0
* https://github.com/kedacore/http-add-on/releases/tag/v0.9.0

This PR prepares for kedify/http-add-on chart release with Kedify-flavoured images based on the latest release.