### PR TITLE
ci: add missing permissions for kedify-agent release

### DIFF
--- a/.github/workflows/milestones-tracker.yaml
+++ b/.github/workflows/milestones-tracker.yaml
@@ -6,6 +6,9 @@ on:
     paths:
       - kedify-agent/**
 
+permissions:
+  contents: write
+
 jobs:
   milestone_tracker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
the job failed to create the release
https://github.com/kedify/charts/actions/runs/12788712352/job/35650558916

```
release PR #90 with milestone: kedify-agent/v0.0.10
creating release kedify-agent/v0.0.10
HTTP 403: Resource not accessible by integration (https://api.github.com/repos/kedify/charts/releases)
```