### PR TITLE
ci: trigger helm package on release publish

### DIFF
--- a/.github/workflows/publish-chart-from-release.yaml
+++ b/.github/workflows/publish-chart-from-release.yaml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - 'kedify-agent/v*.*.*'
+  release:
+    types: [published]
 
 jobs:
   publish-chart:


### PR DESCRIPTION
when the release is created, the tag is also created but the push tag event is not triggered