### PR TITLE
adding back the Disabled value

### DIFF
--- a/kedify-agent/files/kedify-configuration.yaml
+++ b/kedify-agent/files/kedify-configuration.yaml
@@ -178,6 +178,7 @@ spec:
                       - InstallOnly
                       - Adopt
                       - Auto
+                      - Disabled
                       type: string
                     name:
                       description: Name of the KEDA installation


### PR DESCRIPTION
I removed the `Disabled` as a valid value for the mode in my previous commit so adding it back. I ran `make manifest` on agent repo and blindly copy&pasted the result, but it seems we were missing it there, so opening a PR there as well - https://github.com/kedify/agent/pull/297

W/o this fix the helm chart is not installable, because the job that creates CR (kedify) fails

tested by:
```
DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"

k3d cluster delete || true 2> /dev/null
sleep 0.2
k3d cluster create
for i in ghcr.io/kedify/keda-operator:v2.16.0-1 \
  ghcr.io/kedify/http-add-on-scaler:v0.8.1-8 \
  ghcr.io/kedify/http-add-on-interceptor:v0.8.1-8 \
  ghcr.io/kedify/keda-admission-webhooks:v2.16.0-1 \
  ghcr.io/kedify/keda-operator:v2.16.0-1 \
  ghcr.io/kedify/keda-metrics-apiserver:v2.16.0-1 \
  ghcr.io/kedify/agent:v0.1.12 \
 ; do
  echo Pulling image: $i
  docker pull $i
  echo Importing image: $i
  k3d image import $i
done

helm upgrade --install keda kedifykeda/keda --namespace keda --create-namespace --version v2.16.1-0 --values "$DIR"/values_keda.yaml
helm upgrade --install keda-add-ons-http kedifykeda/keda-add-ons-http --namespace keda --version v0.9.0-2 --values "$DIR"/values_addon.yaml


# PROD
#helm upgrade --install kedify-agent kedifykeda/kedify-agent --namespace keda --values "$DIR"/values_agent.yaml --version v0.0.11 --set clusterName=test-helm-$(head /dev/urandom | sha1sum | cut -c1-8)


# DEV
helm upgrade -i kedify-agent kedify-agent/ --namespace keda --set clusterName=test-helm-$(head /dev/urandom | shasum | cut -c1-8) \
  --set agent.orgId=** \
  --set agent.apiKey=** \
  --set agent.kedifyServer=34.70.48.187:443 \
  --set agent.logLevel=10
```

after some time:

```
λ k get kedifyconfigurations.install.kedify.io -A
NAMESPACE   NAME     VERSION   MODE       AGENT     KEDA   API SERVICE   CREATED
keda        kedify             Disabled   Running          Running       3m30s
```

note:
sometimes, if the svc for keda-operator-metrics-apiserver is not ready, because it takes some time to pull the image + the deployments wait for `kedaorg-certs` secret to be create by KEDA operator. Then the API registration is also not ok, because of the unaccessible svc:

```
v1beta1.external.metrics.k8s.io        keda/keda-operator-metrics-apiserver   False (MissingEndpoints)   2m18s
```

In this situation, the kedify agent reports those weird:

```
2025/01/22 17:18:23 Failed to refresh API resource cache for all: unable to retrieve the complete list of server APIs: external.metrics.k8s.io/v1beta1: stale GroupVersion discovery: external.metrics.k8s.io/v1beta1
```

messages. It's not RBAC issue to my knowledge. Eventually, everything starts fine.