### PR TITLE
ci: add permissions for milestones tracking

### DIFF
--- a/.github/workflows/milestones-tracker.yaml
+++ b/.github/workflows/milestones-tracker.yaml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   milestone_tracker:


### PR DESCRIPTION
fix for
```
Run set -euo pipefail
setting 'kedify-agent/next' milestone for PR #100
GraphQL: Resource not accessible by integration (updatePullRequest)
Error: Process completed with exit code 1.
```
https://github.com/kedify/charts/actions/runs/12932478248/job/36068802207