### PR TITLE
Bump kedify-agent helm chart version to v0.1.12

### DIFF
--- a/kedify-agent/Chart.yaml
+++ b/kedify-agent/Chart.yaml
@@ -3,7 +3,7 @@ name: kedify-agent
 description: Kedify agent - Helm Chart
 kubeVersion: ">=v1.23.0-0"
 type: application
-version: "v0.0.11"
+version: "v0.0.12"
 appVersion: "v0.1.12"
 icon: https://github.com/kedify/marketing/raw/refs/heads/main/public/assets/images/logo.svg
 dependencies:


### PR DESCRIPTION
# Chart v0.1.12 CHANGELOG:
* adding back the Disabled value
* agent image version bump to v0.1.12

# Image v0.1.12 CHANGELOG:
## Features:
* Add a way to install also helm charts deployed in OCI registry

## Fixes:
* Add Disabled as a valid value for mode
