### PR TITLE
Allow for creating the secret w/ api key by other tools

### DIFF
--- a/kedify-agent/templates/api-key-secret.yaml
+++ b/kedify-agent/templates/api-key-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.agent.createApiKeySecret }}
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -6,3 +7,4 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   apikey: {{ b64enc .Values.agent.apiKey }}
+{{- end }}

--- a/kedify-agent/values.schema.json
+++ b/kedify-agent/values.schema.json
@@ -16,17 +16,29 @@
     "Agent": {
       "properties": {
         "apiKey": {
-          "type": "string",
-          "minLength": 10,
-          "pattern": "^kfy_[a-z0-9]*$"
+          "type": "string"
+        },
+        "createApiKeySecret": {
+          "type": "boolean"
         },
         "orgId": {
           "type": "string",
           "format": "uuid"
         }
       },
+      "if": {
+        "properties": {
+          "createApiKeySecret": { "const": true }
+        }
+      },
+      "then": {
+        "properties": {
+          "apiKey": { "pattern": "^kfy_[a-z0-9]*$", "minLength": 10 }
+        }
+      },
       "required": [
         "apiKey",
+        "createApiKeySecret",
         "orgId"
       ]
     }

--- a/kedify-agent/values.yaml
+++ b/kedify-agent/values.yaml
@@ -7,6 +7,9 @@ agent:
   orgId: ""
   # you should already have this
   apiKey: ""
+  # if disabled, the Secret called 'kedify-agent' with api key has to be created by some other entity,
+  # otherwise agent won't start
+  createApiKeySecret: true
   # agentId: abcd1234-ab34-..
   kedifyServer: service.kedify.io:443
 


### PR DESCRIPTION
why: There are tools like sealed secret operator from Bitnami, SOPS from mozilla or [vault-csi-provider](https://github.com/hashicorp/vault-csi-provider), that allow creating and managing secrets. I think we should allow users to use these or similar tools together w/ the kedify-agent. So the idea is to have a new flag called `agent.createApiKeySecret` (`true` by default) that controls the rendering of k8s secret w/ the apiKey and also the schema validation for `agent.apiKey` field.

status quo:

```
λ helm template .
Error: values don't meet the specifications of the schema(s) in the following chart(s):
kedify-agent:
- agent: Must validate "then" as "if" was valid
- agent.apiKey: String length must be greater than or equal to 10
- agent.apiKey: Does not match pattern '^kfy_[a-z0-9]*$'
- agent.orgId: Does not match format 'uuid'

λ helm template . --set agent.apiKey=kfy_foo123456 --set agent.orgId=00000000-0000-0000-0000-000000000000 | grep Secret
kind: Secret
```

new flag:

```
helm template . --set agent.createApiKeySecret=false
Error: values don't meet the specifications of the schema(s) in the following chart(s):
kedify-agent:
- agent.orgId: Does not match format 'uuid'

λ helm template . --set agent.createApiKeySecret=false --set agent.orgId=00000000-0000-0000-0000-000000000000 | grep Secret
# tumbleweed.gif
```