### PR TITLE
ci: idempotent release pipeline

### DIFF
--- a/.github/workflows/milestones-tracker.yaml
+++ b/.github/workflows/milestones-tracker.yaml
@@ -59,8 +59,12 @@ jobs:
           release_tag=${milestone#*/}
           pr_body="$(gh pr view $PR_NUMBER --json 'body' --jq '.body')" 
 
-          echo "creating release $milestone"
-          gh release create -R kedify/charts "$milestone" --latest --title "${{ inputs.chart }}: $release_tag" --notes "${pr_body}"
+          if gh release view $milestone > /dev/null; then
+              echo "release $milestone already exists"
+          else
+              echo "creating release $milestone"
+              gh release create -R kedify/charts "$milestone" --latest --title "${{ inputs.chart }}: $release_tag" --notes "${pr_body}"
+          fi
           echo "should_release=true" >> $GITHUB_OUTPUT
   release:
     needs: milestone_tracker


### PR DESCRIPTION
Checking if previous partially successful run already created the release, on nonexisting releases, the `gh` command returns non-zero status code
```
$ gh release view kedify-agent/v0.0.14 --json 'tagName'
release not found

$ echo $?
1
```