### PR TITLE
ci: http-add-on PR tests: patch missing cli arg from upstream main

### DIFF
--- a/.github/workflows/ci-http-add-on.yml
+++ b/.github/workflows/ci-http-add-on.yml
@@ -74,7 +74,9 @@ jobs:
         run: kubectl create ns keda
 
       - name: Install KEDA chart
-        run: helm install keda ./keda/ --namespace keda
+        run: |
+          helm template keda ./keda/ --namespace keda | grep -ve '--enable-webhook-patching=' > keda.yaml
+          kubectl apply --server-side -f keda.yaml
 
       - name: Generate values
         run: |


### PR DESCRIPTION
In the PR smoke tests, keda-operator is not starting up because of currently unreleased cli flag that merged only to keda upstream main
```
$ k logs keda-operator-7fc4db746f-k7ql6
2025/02/13 15:50:22 maxprocs: Updating GOMAXPROCS=1: determined from CPU quota
unknown flag: --enable-webhook-patching
```
for the purposes of this PR test, we can patch the KEDA deployment to not have this argument.