### PR TITLE
agent: enhance logging configuration

### DIFF
--- a/kedify-agent/templates/agent-deployment.yaml
+++ b/kedify-agent/templates/agent-deployment.yaml
@@ -26,8 +26,13 @@ spec:
     spec:
       containers:
         - args:
-            - --leader-elect
-            - --zap-log-level={{ .Values.agent.logLevel }}
+          - --leader-elect
+          - --zap-log-level={{ default .Values.agent.logLevel .Values.agent.logging.level }}
+          - --zap-log-format={{ .Values.agent.logging.format }}
+          - --zap-log-time-encoding={{ .Values.agent.logging.timeEncoding }}
+          {{- if .Values.agent.logging.stackTracesEnabled }}
+          - --zap-stacktrace-level=error
+          {{- end }}
           command:
             - /manager
           env:

--- a/kedify-agent/values.yaml
+++ b/kedify-agent/values.yaml
@@ -14,13 +14,24 @@ agent:
   agentId: ""
   kedifyServer: service.kedify.io:443
 
-  # Can be one of 'debug', 'info', 'error', or any integer value > 0
-  # which corresponds to custom debug levels of increasing verbosity
-  logLevel: info
+  
+  logging:
+    # Log level for the agent
+    # Can be one of 'debug', 'info', 'error', or any integer value > 0
+    # which corresponds to custom debug levels of increasing verbosity
+    level: info
+    # Log format for the agent
+    # allowed values: 'console' or 'json'
+    format: console
+    # Log time encoding for the agent
+    # allowed values are 'epoch', 'millis', 'nano', 'iso8601', 'rfc3339' or 'rfc3339nano'
+    timeEncoding: RFC3339
+    # Display stack traces in the logs
+    stackTracesEnabled: false
 
   kedifyProxy:
     # Log format for kedify-proxy
-    logFormat: plaintext # plaintext or json
+    logFormat: plaintext # 'plaintext' or 'json'
     # enable to set cluster wide deployment (supported only for istio VirtualService and Gatewa API HTTPRoute)
     # otherwise it will be dynamically deployed in each namespace with HTTPScaledObject
     clusterWide: false


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->


Add a way to configure log level, format, time encoding and stacktraces enablement.

Adding a bit of structure into the logging settings to be aligned with the rest of the stack (KEDA, HTTP Add-on...)

The old way of setting agent logLevel, has been preserved for backwards compatibility: `agent.logLevel`
But the new preferred way is via `agent.logging.level`

