### PR TITLE
interceptor: set endpoints cache 20s interval

### DIFF
--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -160,7 +160,7 @@ interceptor:
   # -- How long the interceptor will wait between forwarding a request to a backend and receiving response headers back before failing the request
   responseHeaderTimeout: 500ms
   # -- How often (in milliseconds) the interceptor does a full refresh of its endpoints cache. The interceptor will also use Kubernetes events to stay up-to-date with the endpoints cache changes. This duration is the maximum time it will take to see changes to the endpoints.
-  endpointsCachePollingIntervalMS: 250
+  endpointsCachePollingIntervalMS: 20000
   # -- Whether or not the interceptor should force requests to use HTTP/2
   forceHTTP2: true
   # -- The maximum number of idle connections allowed in the interceptor's in-memory connection pool. Set to 0 to indicate no limit


### PR DESCRIPTION
Bumping the interval from 250ms (which gets rejected by kubernetes client go and bumped to 1s anyways) to 20s
```
W0219 15:54:25.513436       1 shared_informer.go:591] resyncPeriod 250ms is too small. Changing it to the minimum allowed value of 1s
```
Can't currently get higher than 20s because of this check
https://github.com/kedacore/http-add-on/blob/61d52ca769f18d6fd112e975a31d131150bee3dc/interceptor/config/validate.go#L29-L36

the description is also incorrect
> -- How often (in milliseconds) the interceptor does a full refresh of its endpoints cache. The interceptor will also use Kubernetes events to stay up-to-date with the endpoints cache changes. This duration is the maximum time it will take to see changes to the endpoints.

This doesn't do any refresh with kube-api, it flushes the current content of the informer cache and triggers a control loop for each element currently in the cache. There is no need to have this any less than inf because endpoints changes are acted upon through events, but 20s at least won't overload the interceptor too much.