### PR TITLE
http-add-on: custom headers for proxied traffic

### DIFF
--- a/http-add-on/templates/interceptor/deployment.yaml
+++ b/http-add-on/templates/interceptor/deployment.yaml
@@ -69,6 +69,28 @@ spec:
           value: "{{ .Values.interceptor.tlsHandshakeTimeout }}"
         - name: KEDA_HTTP_EXPECT_CONTINUE_TIMEOUT
           value: "{{ .Values.interceptor.expectContinueTimeout }}"
+        {{- if (and .Values.interceptor .Values.interceptor.customHeaders) }}
+        {{- if .Values.interceptor.customHeaders.interceptor }}
+        {{- if .Values.interceptor.customHeaders.interceptor.request }}
+        - name: KEDA_HTTP_CUSTOM_INTERCEPTOR_REQUEST_HEADERS
+          value: "{{ .Values.interceptor.customHeaders.interceptor.request }}"
+        {{- end }}
+        {{- if .Values.interceptor.customHeaders.interceptor.response }}
+        - name: KEDA_HTTP_CUSTOM_INTERCEPTOR_RESPONSE_HEADERS
+          value: "{{ .Values.interceptor.customHeaders.interceptor.response }}"
+        {{- end }}
+        {{- end }}
+        {{- if .Values.interceptor.customHeaders.kedifyProxy }}
+        {{- if .Values.interceptor.customHeaders.kedifyProxy.request }}
+        - name: KEDA_HTTP_CUSTOM_KEDIFY_PROXY_REQUEST_HEADERS
+          value: "{{ .Values.interceptor.customHeaders.kedifyProxy.request }}"
+        {{- end }}
+        {{- if .Values.interceptor.customHeaders.kedifyProxy.response }}
+        - name: KEDA_HTTP_CUSTOM_KEDIFY_PROXY_RESPONSE_HEADERS
+          value: "{{ .Values.interceptor.customHeaders.kedifyProxy.response }}"
+        {{- end }}
+        {{- end }}
+        {{- end }}
         {{- if .Values.interceptor.tls.enabled }}
         - name: KEDA_HTTP_PROXY_TLS_ENABLED
           value: "true"

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -232,6 +232,16 @@ interceptor:
     # -- The maximum number of replicas that can be unavailable for the interceptor
     maxUnavailable: 1
 
+  # custom headers added to requests and responses passing through the interceptor and/or kedify-proxy
+  # for multiple headers, separate them with a comma, e.g. h1:v1,h2:v2
+  # customHeaders:
+  #   interceptor:
+  #     request: "X-Kedify-Interceptor:True"
+  #     response: "X-Kedify-Interceptor:True"
+  #   kedifyProxy:
+  #     request: "X-Kedify-Proxy:True"
+  #     response: "X-Kedify-Proxy:True"
+
 # configuration for the images to use for each component
 images:
   # tag is the image tag to use for all images.


### PR DESCRIPTION
support for custom static headers for proxied requests and responses through both `interceptor` and/or `kedify-proxy`.

see also: https://github.com/kedify/http-add-on/pull/105