### PR TITLE
ci: fix milestones tracker permissions

### DIFF
--- a/.github/workflows/milestones-tracker-http-add-on.yaml
+++ b/.github/workflows/milestones-tracker-http-add-on.yaml
@@ -17,5 +17,6 @@ jobs:
 
     uses: ./.github/workflows/milestones-tracker.yaml
     with:
+      ghToken: ${{ secrets.CI_MILESTONES_PAT }}
       chart: http-add-on
       prNumber: ${{ github.event.pull_request.number }}

--- a/.github/workflows/milestones-tracker-keda.yaml
+++ b/.github/workflows/milestones-tracker-keda.yaml
@@ -17,5 +17,6 @@ jobs:
 
     uses: ./.github/workflows/milestones-tracker.yaml
     with:
+      ghToken: ${{ secrets.CI_MILESTONES_PAT }}
       chart: keda
       prNumber: ${{ github.event.pull_request.number }}

--- a/.github/workflows/milestones-tracker-kedify-agent.yaml
+++ b/.github/workflows/milestones-tracker-kedify-agent.yaml
@@ -17,5 +17,6 @@ jobs:
 
     uses: ./.github/workflows/milestones-tracker.yaml
     with:
+      ghToken: ${{ secrets.CI_MILESTONES_PAT }}
       chart: kedify-agent
       prNumber: ${{ github.event.pull_request.number }}

--- a/.github/workflows/milestones-tracker-manual.yaml
+++ b/.github/workflows/milestones-tracker-manual.yaml
@@ -26,5 +26,6 @@ jobs:
 
     uses: ./.github/workflows/milestones-tracker.yaml
     with:
+      ghToken: ${{ github.token }}
       chart: ${{ inputs.chart }}
       prNumber: ${{ inputs.prNumber }}

--- a/.github/workflows/milestones-tracker.yaml
+++ b/.github/workflows/milestones-tracker.yaml
@@ -3,6 +3,10 @@ name: milestones tracking with release
 on:
   workflow_call:
     inputs:
+      ghToken:
+        description: 'GitHub token'
+        type: string
+        required: true
       chart:
         description: 'chart name'
         type: string
@@ -27,7 +31,7 @@ jobs:
       - name: Ensure correct milestone
         id: milestone_tracking
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ inputs.ghToken }}
           PR_NUMBER: ${{ inputs.prNumber }}
         run: |
           set -euo pipefail
@@ -75,7 +79,7 @@ jobs:
         uses: wozniakjan/helm-gh-pages@single_chart_path
         if: "${{ needs.milestone_tracker.outputs.should_release == 'true' }}"
         with:
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ inputs.ghToken }}
           linting: "off"
           dependencies: "kedify,https://kedify.github.io/charts"
           charts_dir: "."


### PR DESCRIPTION
workflow has insufficient permissions and fails for PRs from forks (only forks)
```
setting 'http-add-on/next' milestone for PR #119
GraphQL: Resource not accessible by integration (updatePullRequest)
```
https://github.com/kedify/charts/actions/runs/13438412320/job/37546375862