### PR TITLE
ci: milestone tracker without secrets

### DIFF
--- a/.github/workflows/milestones-tracker-http-add-on.yaml
+++ b/.github/workflows/milestones-tracker-http-add-on.yaml
@@ -9,14 +9,13 @@ on:
 jobs:
   milestone_tracker:
     if: github.event.pull_request.merged == true
-    secrets: inherit
 
     permissions:
       contents: write
       pull-requests: write
+      packages: write
 
     uses: ./.github/workflows/milestones-tracker.yaml
     with:
-      ghToken: ${{ secrets.CI_MILESTONES_PAT }}
       chart: http-add-on
       prNumber: ${{ github.event.pull_request.number }}

--- a/.github/workflows/milestones-tracker-keda.yaml
+++ b/.github/workflows/milestones-tracker-keda.yaml
@@ -9,14 +9,13 @@ on:
 jobs:
   milestone_tracker:
     if: github.event.pull_request.merged == true
-    secrets: inherit
 
     permissions:
       contents: write
       pull-requests: write
+      packages: write
 
     uses: ./.github/workflows/milestones-tracker.yaml
     with:
-      ghToken: ${{ secrets.CI_MILESTONES_PAT }}
       chart: keda
       prNumber: ${{ github.event.pull_request.number }}

--- a/.github/workflows/milestones-tracker-kedify-agent.yaml
+++ b/.github/workflows/milestones-tracker-kedify-agent.yaml
@@ -9,14 +9,13 @@ on:
 jobs:
   milestone_tracker:
     if: github.event.pull_request.merged == true
-    secrets: inherit
 
     permissions:
       contents: write
       pull-requests: write
+      packages: write
 
     uses: ./.github/workflows/milestones-tracker.yaml
     with:
-      ghToken: ${{ secrets.CI_MILESTONES_PAT }}
       chart: kedify-agent
       prNumber: ${{ github.event.pull_request.number }}

--- a/.github/workflows/milestones-tracker-manual.yaml
+++ b/.github/workflows/milestones-tracker-manual.yaml
@@ -19,13 +19,11 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  packages: write
 
 jobs:
   milestone_tracker:
-    secrets: inherit
-
     uses: ./.github/workflows/milestones-tracker.yaml
     with:
-      ghToken: ${{ github.token }}
       chart: ${{ inputs.chart }}
       prNumber: ${{ inputs.prNumber }}

--- a/.github/workflows/milestones-tracker.yaml
+++ b/.github/workflows/milestones-tracker.yaml
@@ -3,10 +3,6 @@ name: milestones tracking with release
 on:
   workflow_call:
     inputs:
-      ghToken:
-        description: 'GitHub token'
-        type: string
-        required: true
       chart:
         description: 'chart name'
         type: string
@@ -16,10 +12,10 @@ on:
         type: string
         required: true
 
-
 permissions:
   contents: write
   pull-requests: write
+  packages: write
 
 jobs:
   milestone_tracker:
@@ -31,7 +27,7 @@ jobs:
       - name: Ensure correct milestone
         id: milestone_tracking
         env:
-          GH_TOKEN: ${{ inputs.ghToken }}
+          GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ inputs.prNumber }}
         run: |
           set -euo pipefail
@@ -79,7 +75,7 @@ jobs:
         uses: wozniakjan/helm-gh-pages@single_chart_path
         if: "${{ needs.milestone_tracker.outputs.should_release == 'true' }}"
         with:
-          token: ${{ inputs.ghToken }}
+          token: ${{ github.token }}
           linting: "off"
           dependencies: "kedify,https://kedify.github.io/charts"
           charts_dir: "."


### PR DESCRIPTION
I was on a wrong path with https://github.com/kedify/charts/pull/122. The release PRs (e.g. https://github.com/kedify/charts/pull/113) are pushed by the bot directly to kedify/charts repo and as a result see the secrets so there are no failures. But PRs from contributors (e.g. https://github.com/kedify/charts/pull/121) come from forks and they don't get to see secrets so this still fails. The automated milestones tracker must be written in a way to not need secrets to support both forked and non-forked workflows.