### PR TITLE
http-add-on: release v0.10.0-0

### DIFF
--- a/http-add-on/Chart.yaml
+++ b/http-add-on/Chart.yaml
@@ -11,12 +11,12 @@ kubeVersion: ">=v1.23.0-0"
 # to the chart and its templates, including the app version. This is incremented at chart release time and does not need
 # to be included in any PRs to main.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.0
+version: v0.10.0-0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.10.0
+appVersion: v0.10.0-0
 home: https://github.com/kedacore/http-add-on
 sources:
   - https://github.com/kedacore/http-add-on

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -252,7 +252,7 @@ images:
   # the build for the latest commit to the `main` branch,
   # and you can target any other commit with `sha-<GIT_SHA[0:7]>`
   # -- Image tag for the http add on. This tag is applied to the images listed in `images.operator`, `images.interceptor`, and `images.scaler`. Optional, given app version of Helm chart is used by default
-  tag: v0.9.0-5
+  tag: v0.10.0-0
   # -- Image name for the operator image component
   operator: ghcr.io/kedify/http-add-on-operator
   # -- Image name for the interceptor image component


### PR DESCRIPTION
# Chart v0.10.0-0 CHANGELOG:
* http-add-on: custom headers for proxied traffic ([#121](https://github.com/kedify/charts/pull/121))
* http-add-on: kedify-proxy access log config ([#119](https://github.com/kedify/charts/pull/119))
* interceptor: set endpoints cache 20s interval ([#118](https://github.com/kedify/charts/pull/118))
* image version bump to v0.10.0-0

# Image v0.10.0-0 CHANGELOG:
## Upstream Release:
* https://github.com/kedacore/http-add-on/releases/tag/v0.10.0

## Features:
* interceptor: custom headers for requests and responses
* envoy xDS: configurable access logs for kedify-proxy

## Fixes:
* envoy xDS: dynamic timeout for cold starts