### PR TITLE
Add optional field cloud-provider for billing

### DIFF
--- a/kedify-agent/templates/agent-deployment.yaml
+++ b/kedify-agent/templates/agent-deployment.yaml
@@ -47,6 +47,8 @@ spec:
                 secretKeyRef:
                   name: kedify-agent
                   key: apikey
+            - name: CLOUD_PROVIDER
+              value: {{ .Values.agent.billingCloudProvider }}
             - name: KEDIFY_PROXY_CHART_VERSION
               value: {{ .Values.agent.kedifyProxy.chartVersion | quote }}
             - name: KEDIFY_PROXY_CLUSTER_WIDE

--- a/kedify-agent/values.schema.json
+++ b/kedify-agent/values.schema.json
@@ -35,6 +35,21 @@
               "format": "uuid"
             }
           ]
+        },
+        "billingCloudProvider": {
+          "type": "string",
+          "anyOf": [
+            {
+              "maxLength": 0
+            },
+            {
+              "enum": [
+                "aws",
+                "azure",
+                "gcp"
+              ]
+            }
+          ]
         }
       },
       "if": {

--- a/kedify-agent/values.yaml
+++ b/kedify-agent/values.yaml
@@ -13,6 +13,9 @@ agent:
   # if migrating to helm, set this to the value of the agentId from the previous installation
   agentId: ""
   kedifyServer: service.kedify.io:443
+  # optional field, if you use a mix of cloud providers for billing, you can specify the cloud provider
+  # for the billing purposes for this Agent (supported values: "aws", "gcp", "azure")
+  billingCloudProvider: ""
 
   
   logging:


### PR DESCRIPTION
In case a customer is using a mix of cloud marketplace integrations - they can specify which agent should be billed under which cloud provider.