### PR TITLE
agent: fix zap logger flags

### DIFF
--- a/kedify-agent/templates/agent-deployment.yaml
+++ b/kedify-agent/templates/agent-deployment.yaml
@@ -28,8 +28,8 @@ spec:
         - args:
           - --leader-elect
           - --zap-log-level={{ default .Values.agent.logLevel .Values.agent.logging.level }}
-          - --zap-log-format={{ .Values.agent.logging.format }}
-          - --zap-log-time-encoding={{ .Values.agent.logging.timeEncoding }}
+          - --zap-encoder={{ .Values.agent.logging.format }}
+          - --zap-time-encoding={{ .Values.agent.logging.timeEncoding }}
           {{- if .Values.agent.logging.stackTracesEnabled }}
           - --zap-stacktrace-level=error
           {{- end }}


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

Supported zap flags in the binary
```
  -zap-devel
        Development Mode defaults(encoder=consoleEncoder,logLevel=Debug,stackTraceLevel=Warn). Production Mode defaults(encoder=jsonEncoder,logLevel=Info,stackTraceLevel=Error) (default true)
  -zap-encoder value
        Zap log encoding (one of 'json' or 'console')
  -zap-log-level value
        Zap Level to configure the verbosity of logging. Can be one of 'debug', 'info', 'error', or any integer value > 0 which corresponds to custom debug levels of increasing verbosity
  -zap-stacktrace-level value
        Zap Level at and above which stacktraces are captured (one of 'info', 'error', 'panic').
  -zap-time-encoding value
        Zap time encoding (one of 'epoch', 'millis', 'nano', 'iso8601', 'rfc3339' or 'rfc3339nano'). Defaults to 'epoch'.
```