### PR TITLE
kedify-proxy: preStop hook with readinessProbe

### DIFF
--- a/kedify-proxy/templates/envoy-deployment.yaml
+++ b/kedify-proxy/templates/envoy-deployment.yaml
@@ -40,6 +40,17 @@ spec:
             - "--config-yaml"
             - "$(ENVOY_CONFIG)"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    echo "Gracefully shutting down kedify-proxy"
+                    exec 3<>/dev/tcp/localhost/{{ .Values.service.adminPort }}
+                    echo -e 'POST /healthcheck/fail HTTP/1.1\r\nHost: localhost\r\nContent-Length:0\r\n\r\n' >&3
+                    sleep {{ .Values.pod.preStopHookWaitSeconds }}
           env:
             - name: ENVOY_UID
               value: {{ .Values.pod.containerSecurityContext.runAsUser | quote }}
@@ -61,6 +72,7 @@ spec:
             - name: admin
               containerPort: {{ .Values.service.adminPort }}
               protocol: TCP
+          terminationGracePeriodSeconds: {{ .Values.pod.terminationGracePeriodSeconds }}
           livenessProbe:
             httpGet:
               path: /ready
@@ -72,9 +84,9 @@ spec:
             httpGet:
               path: /ready
               port: admin
-              {{- with .Values.pod.readinessProbe }}
-              {{- toYaml . | nindent 14 }}
-              {{- end }}
+            {{- with .Values.pod.readinessProbe }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- with .Values.volumeMounts }}

--- a/kedify-proxy/values.yaml
+++ b/kedify-proxy/values.yaml
@@ -43,10 +43,14 @@ pod:
   # -- custom timeouts and thresholds for liveness probe
   livenessProbe: {}
   # -- custom timeouts and thresholds for readiness probe
-  readinessProbe: {}
-    # periodSeconds: 30
-    # initialDelaySeconds: 5
-    # failureThreshold: 2
+  readinessProbe:
+    periodSeconds: 1
+    initialDelaySeconds: 1
+    failureThreshold: 2
+  # -- custom timeout for graceful shutdown, should be larger than: readiness probe threshold * period
+  preStopHookWaitSeconds: 5
+  # -- custom timeout for pod termination, should be larger than: preStopHookWaitSeconds + (readiness probe threshold * period)
+  terminationGracePeriodSeconds: 30
 
 deployment:
   # -- Fixed amount of replicas for the deployment. Use either `.autoscaling` section or this field.


### PR DESCRIPTION
With kedify-proxy being scalable, the connections need to be drained first by calling this endpoint on the envoy admin port
```
/healthcheck/fail
```
This ensures envoy won't pass readinessProbe so it will be excluded from the service loadbalancing.