### PR TITLE
autowire: periodic sync service config

### DIFF
--- a/kedify-agent/templates/agent-deployment.yaml
+++ b/kedify-agent/templates/agent-deployment.yaml
@@ -97,6 +97,8 @@ spec:
               value: {{ .Values.agent.rbac.ingressAutoWire | quote }}
             - name: RBAC_MANAGE_KEDIFY_CONFIG
               value: {{ .Values.agent.rbac.kedifyConfig | quote }}
+            - name: KEDIFY_AUTOWIRE_SERVICE_SYNC_PERIOD
+              value: {{ .Values.agent.autowire.serviceSyncPeriod | quote }}
           image: "{{ .Values.agent.image.repository }}:{{ .Values.agent.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.agent.pullPolicy }}
           livenessProbe:

--- a/kedify-agent/values.yaml
+++ b/kedify-agent/values.yaml
@@ -83,6 +83,9 @@ agent:
     podResourceProfilesEnabled: false
     prpRequiresAnnotatedPods: true
 
+  autowire:
+    serviceSyncPeriod: 500ms
+
   rbac:
     # create the necessary RBAC for kedify agent
     create: true


### PR DESCRIPTION
global configuration for service autowiring periodic sync, defaults to 500ms.

Can be further fine-tuned per `ScaledObject` with `http.kedify.io/service-resync-period` annotation.