### PR TITLE
keda: release v2.16.1-1

### DIFF
--- a/keda/Chart.yaml
+++ b/keda/Chart.yaml
@@ -8,11 +8,11 @@ kubeVersion: ">=v1.23.0-0"
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.16.1
+version: 2.16.1-1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.16.1
+appVersion: 2.16.1-1
 
 home: https://github.com/kedacore/keda
 icon: https://raw.githubusercontent.com/kedacore/keda/main/images/keda-logo-500x500-white.png

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -14,21 +14,21 @@ image:
     # -- Image name of KEDA operator
     repository: kedify/keda-operator
     # -- Image tag of KEDA operator. Optional, given app version of Helm chart is used by default
-    tag: "v2.16.1-0"
+    tag: "v2.16.1-1"
   metricsApiServer:
     # -- Image registry of KEDA Metrics API Server
     registry: ghcr.io
     # -- Image name of KEDA Metrics API Server
     repository: kedify/keda-metrics-apiserver
     # -- Image tag of KEDA Metrics API Server. Optional, given app version of Helm chart is used by default
-    tag: "v2.16.1-0"
+    tag: "v2.16.1-1"
   webhooks:
     # -- Image registry of KEDA admission-webhooks
     registry: ghcr.io
     # -- Image name of KEDA admission-webhooks
     repository: kedify/keda-admission-webhooks
     # -- Image tag of KEDA admission-webhooks . Optional, given app version of Helm chart is used by default
-    tag: "v2.16.1-0"
+    tag: "v2.16.1-1"
   # -- Image pullPolicy for all KEDA components
   pullPolicy: Always
 


### PR DESCRIPTION
# Chart v2.16.1-1 CHANGELOG:
* image version bump to v2.16.1-1

# Image v2.16.1-1 CHANGELOG:
## Fixes:
* fix: delete any orphan `HTTPScaledObjects` during the `ScaledObject` update