### PR TITLE
kedify-proxy: fix missing metric type in default SO

### DIFF
--- a/kedify-proxy/templates/so.yaml
+++ b/kedify-proxy/templates/so.yaml
@@ -11,9 +11,11 @@ spec:
     - type: cpu
       metadata:
         value: "75"
+      metricType: Utilization
     - type: memory
       metadata:
-        value: "75"
+        value: "90"
+      metricType: Utilization
   minReplicaCount: {{ .Values.autoscaling.minReplicaCount }}
   maxReplicaCount: {{ .Values.autoscaling.maxReplicaCount }}
   advanced:


### PR DESCRIPTION
the default `ScaledObject` for kedify-proxy doesn't work with KEDA 2.16.1, the CPU trigger is missing `MetricType`

```
  Warning  ScaledObjectCheckFailed  13m (x12 over 13m)    keda-operator  failed to ensure HPA is correctly created for ScaledObject
  Warning  KEDAScalerFailed         7m56s (x17 over 13m)  keda-operator  error parsing cpu metadata: unknown metric type: , allowed values are 'Utilization' or 'AverageValue'
```

this is being explicitly checked in the [CPU scaler](https://github.com/kedacore/keda/blob/8e1039cc1bb3a356be0a31993db4cd0ec20f20a8/pkg/scalers/cpu_memory_scaler.go#L84)
