### PR TITLE
http-add-on: exposing metrics port on interceptor deployment

### DIFF
--- a/http-add-on/templates/interceptor/deployment.yaml
+++ b/http-add-on/templates/interceptor/deployment.yaml
@@ -121,6 +121,8 @@ spec:
           name: admin
         - containerPort: {{ .Values.interceptor.proxy.port }}
           name: proxy
+        - containerPort: {{ default 2223 .Values.interceptor.metrics.port }}
+          name: metrics 
         {{- if .Values.interceptor.tls.enabled }}
         - containerPort: {{ .Values.interceptor.tls.port }}
           name: proxy-tls


### PR DESCRIPTION
the metrics service exposes metrics port for interceptor
https://github.com/kedify/charts/blob/2c23303476d6bf05427d62348edcc29cc59acb4a/http-add-on/templates/interceptor/service-metrics.yaml#L12-L14

this is missing in the deployment pod spec which makes it harder to use GKE pod monitoring, because it expects the port to be defined on the pod level too
https://cloud.google.com/stackdriver/docs/managed-prometheus/setup-managed#gmp-pod-monitoring