### PR TITLE
scaling groups: CRD and RBAC

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -182,7 +182,10 @@ jobs:
       run: helm template keda ./keda/ --namespace ${{ matrix.namespace }} --values test-values.yaml
 
     - name: Install Helm chart
-      run: helm install keda ./keda/ --namespace ${{ matrix.namespace }} --values test-values.yaml --wait
+      run: |
+        # temporary workaround for upstream unreleased CLI argument
+        sed -i 's/^.*--enable-webhook-patching=.*$//' ./keda/templates/manager/deployment.yaml
+        helm install keda ./keda/ --namespace ${{ matrix.namespace }} --values test-values.yaml --wait
 
     - name: Show Kubernetes resources (KEDA)
       run: kubectl get all --namespace ${{ matrix.namespace }}

--- a/keda/templates/crds/crd-scalinggroups.yaml
+++ b/keda/templates/crds/crd-scalinggroups.yaml
@@ -1,0 +1,270 @@
+{{- if .Values.crds.install }}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+    {{- if (or .Values.crds.additionalAnnotations .Values.additionalAnnotations) }}
+    {{- toYaml (merge .Values.crds.additionalAnnotations .Values.additionalAnnotations) | nindent 4 }}
+    {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.operator.name }}
+    {{- include "keda.crd-labels" . | indent 4 }}
+  name: scalinggroups.keda.kedify.io
+spec:
+  group: keda.kedify.io
+  names:
+    kind: ScalingGroup
+    listKind: ScalingGroupList
+    plural: scalinggroups
+    shortNames:
+    - sg
+    singular: scalinggroup
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.capacity
+      name: Capacity
+      type: integer
+    - jsonPath: .status.residualCapacity
+      name: ResidualCapacity
+      type: integer
+    - jsonPath: .status.memberCount
+      name: MemberCount
+      type: integer
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ScalingGroup controls the scaling of a group of scalable objects that have a common cap
+          a group is defined by a label selector and the membership can be dynamically changed
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ScalingGroupSpec defines the desired state of ScalingGroup,
+              total capacity and policy how to allocate resources
+            properties:
+              capacity:
+                description: Capacity is the total max number of replicas that can
+                  be created in the group
+                format: int32
+                minimum: 1
+                type: integer
+              selector:
+                description: Selector is a label selector that defines the group membership
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - capacity
+            - selector
+            type: object
+          status:
+            description: ScalingGroupStatus defines the observed state of ScalingGroup
+              resources that match the selector
+            properties:
+              conditions:
+                description: Conditions is a list of conditions describing status
+                  of this group
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              memberCount:
+                description: MemberCount is the number of scalable objects that match
+                  the selector
+                format: int32
+                type: integer
+              residualCapacity:
+                description: ResidualCapacity is the number of replicas that can be
+                  allocated to the scalable objects
+                format: int32
+                type: integer
+              scaledJobs:
+                additionalProperties:
+                  description: ScalableStatus defines the observed state of a scalable
+                    object (ScaledObject or ScaledJob)
+                  properties:
+                    cappedStatus:
+                      description: CappedStatus contains information about the capped
+                        status of the scalable object
+                      properties:
+                        replicaCountBasedOnMetrics:
+                          description: ReplicaCountBasedOnMetrics is the number of
+                            replicas that would be allocated if the object wasn't
+                            capped
+                          format: int32
+                          type: integer
+                        replicaCountCapped:
+                          description: ReplicaCountCapped is the number of replicas
+                            that are actually allocated to the object and capped
+                          format: int32
+                          type: integer
+                      required:
+                      - replicaCountBasedOnMetrics
+                      - replicaCountCapped
+                      type: object
+                    hpaDesiredReplicaCount:
+                      description: HPADesiredReplicaCount is the desired number of
+                        replicas as reported by the HPA
+                      format: int32
+                      type: integer
+                  required:
+                  - hpaDesiredReplicaCount
+                  type: object
+                description: ScaledJobs is a map of ScaledJob names matching the selector
+                  to their current status
+                type: object
+              scaledObjects:
+                additionalProperties:
+                  description: ScalableStatus defines the observed state of a scalable
+                    object (ScaledObject or ScaledJob)
+                  properties:
+                    cappedStatus:
+                      description: CappedStatus contains information about the capped
+                        status of the scalable object
+                      properties:
+                        replicaCountBasedOnMetrics:
+                          description: ReplicaCountBasedOnMetrics is the number of
+                            replicas that would be allocated if the object wasn't
+                            capped
+                          format: int32
+                          type: integer
+                        replicaCountCapped:
+                          description: ReplicaCountCapped is the number of replicas
+                            that are actually allocated to the object and capped
+                          format: int32
+                          type: integer
+                      required:
+                      - replicaCountBasedOnMetrics
+                      - replicaCountCapped
+                      type: object
+                    hpaDesiredReplicaCount:
+                      description: HPADesiredReplicaCount is the desired number of
+                        replicas as reported by the HPA
+                      format: int32
+                      type: integer
+                  required:
+                  - hpaDesiredReplicaCount
+                  type: object
+                description: ScaledObjects is a map of ScaledObjects names matching
+                  the selector to their current status
+                type: object
+            required:
+            - memberCount
+            - residualCapacity
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+{{- end -}}

--- a/keda/templates/manager/kedify-rbac.yaml
+++ b/keda/templates/manager/kedify-rbac.yaml
@@ -7,6 +7,22 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
+    app.kubernetes.io/name: "kedify-{{ .Values.operator.name }}-scalinggroups-admin"
+    {{- include "keda.labels" . | indent 4 }}
+  name: kedify-{{ .Values.operator.name }}-scalinggroups-admin
+rules:
+- apiGroups: ["keda.kedify.io"]
+  resources: ["scalinggroups", "scalinggroups/status"]
+  verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  {{- with .Values.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
     app.kubernetes.io/name: "kedify-{{ .Values.operator.name }}-http-admin"
     {{- include "keda.labels" . | indent 4 }}
   name: kedify-{{ .Values.operator.name }}-http-admin
@@ -16,6 +32,26 @@ rules:
   verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
 ---
 {{- if not .Values.watchNamespace }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  {{- with .Values.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: kedify-{{ .Values.operator.name }}-scalinggroups-admin
+    {{- include "keda.labels" . | indent 4 }}
+  name: "kedify-{{ .Values.operator.name }}-scalinggroups-admin"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "kedify-{{ .Values.operator.name }}-scalinggroups-admin"
+subjects:
+- kind: ServiceAccount
+  name: {{ (.Values.serviceAccount.operator).name | default .Values.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -38,6 +74,27 @@ subjects:
 {{- else }}
   {{- range ( split "," .Values.watchNamespace ) }}
 # Role binding for namespace '{{ . }}'
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  {{- with $.Values.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: "kedify-{{ $.Values.operator.name }}-scalinggroups-admin"
+    {{- include "keda.labels" $ | indent 4 }}
+  name: "kedify-{{ $.Values.operator.name }}-scalinggroups-admin"
+  namespace: {{ . | trim }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "kedify-{{ $.Values.operator.name }}-scalinggroups-admin"
+subjects:
+- kind: ServiceAccount
+  name: {{ ($.Values.serviceAccount.operator).name | default $.Values.serviceAccount.name }}
+  namespace: {{ $.Release.Namespace }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:


### PR DESCRIPTION
addition of new `ScalingGroups` CRD and RBAC for KEDA

enable with setting this in values:
```yaml
env:
  - name: KEDIFY_SCALINGGROUPS_ENABLED
    value: "true"
```