### PR TITLE
Add missing rbac for kedify proxy installation (watch and list)

### DIFF
--- a/kedify-agent/templates/rbacs/can-install-kedify-proxy.yaml
+++ b/kedify-agent/templates/rbacs/can-install-kedify-proxy.yaml
@@ -34,6 +34,8 @@ rules:
   - delete
   - patch
   - update
+  - watch
+  - list
   resourceNames:
   - kedify-proxy
 - apiGroups:


### PR DESCRIPTION
issue:
```
E0403 02:20:18.150160       1 reflector.go:158] "Unhandled Error" err="k8s.io/client-go@v0.31.1/tools/cache/reflector.go:243: Failed to watch *v1.Deployment: unknown (get deployments.apps)" logger="UnhandledError"
```
