### PR TITLE
Relaxing the schema validation so that helm template doestn't require any inputs

### DIFF
--- a/kedify-agent/values.schema.json
+++ b/kedify-agent/values.schema.json
@@ -22,8 +22,7 @@
           "type": "boolean"
         },
         "orgId": {
-          "type": "string",
-          "format": "uuid"
+          "type": "string"
         },
         "agentId": {
           "type": "string",
@@ -52,21 +51,7 @@
           ]
         }
       },
-      "if": {
-        "properties": {
-          "createApiKeySecret": { "const": true }
-        }
-      },
-      "then": {
-        "properties": {
-          "apiKey": { "pattern": "^kfy_[a-z0-9]*$", "minLength": 10 }
-        }
-      },
-      "required": [
-        "apiKey",
-        "createApiKeySecret",
-        "orgId"
-      ]
+      "required": []
     }
   }
 }


### PR DESCRIPTION
if this is merged then

```
helm template .
```

will not fail on missing inputs (helm chart validation in CI pipeline)