### PR TITLE
addon: envoy connection buffers and backlog config with higher defaults

### DIFF
--- a/http-add-on/templates/interceptor/deployment.yaml
+++ b/http-add-on/templates/interceptor/deployment.yaml
@@ -112,11 +112,11 @@ spec:
         {{- end }}
         - name: KEDIFY_PROXY_ACCESS_LOG_TYPE
           value: "{{ .Values.kedifyProxy.accessLogType }}"
-        {{- if and .Values.interceptor.envoy .Values.interceptor.envoy.listener .Values.interceptor.envoy.listener.tcpBacklogSize }}
+        {{- if ((.Values.interceptor.envoy).listener).tcpBacklogSize }}
         - name: KEDIFY_PROXY_LISTENER_TCP_BACKLOG_SIZE
           value: "{{ .Values.interceptor.envoy.listener.tcpBacklogSize }}"
         {{- end }}
-        {{- if and .Values.interceptor.envoy .Values.interceptor.envoy.perConnectionBufferLimitBytes }}
+        {{- if (.Values.interceptor.envoy).perConnectionBufferLimitBytes }}
         - name: KEDIFY_PROXY_PER_CONNECTION_BUFFER_LIMIT_BYTES
           value: "{{ .Values.interceptor.envoy.perConnectionBufferLimitBytes }}"
         {{- end }}

--- a/http-add-on/templates/interceptor/deployment.yaml
+++ b/http-add-on/templates/interceptor/deployment.yaml
@@ -112,6 +112,14 @@ spec:
         {{- end }}
         - name: KEDIFY_PROXY_ACCESS_LOG_TYPE
           value: "{{ .Values.kedifyProxy.accessLogType }}"
+        {{- if and .Values.interceptor.envoy .Values.interceptor.envoy.listener .Values.interceptor.envoy.listener.tcpBacklogSize }}
+        - name: KEDIFY_PROXY_LISTENER_TCP_BACKLOG_SIZE
+          value: "{{ .Values.interceptor.envoy.listener.tcpBacklogSize }}"
+        {{- end }}
+        {{- if and .Values.interceptor.envoy .Values.interceptor.envoy.perConnectionBufferLimitBytes }}
+        - name: KEDIFY_PROXY_PER_CONNECTION_BUFFER_LIMIT_BYTES
+          value: "{{ .Values.interceptor.envoy.perConnectionBufferLimitBytes }}"
+        {{- end }}
         {{- range .Values.interceptor.additionalEnvVars }}
         - name: "{{ .name }}"
           value: "{{ .value }}"

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -167,11 +167,11 @@ interceptor:
   # -- How long the interceptor waits to establish TCP connections with backends before failing a request.
   # -- This is also used to configure envoy timeouts for both upstream and downstream connections.
   # -- https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/intro/terminology
-  tcpConnectTimeout: 500ms
+  tcpConnectTimeout: 5m
   # -- The interceptor's connection keep alive timeout
   keepAlive: 1s
   # -- How long the interceptor will wait between forwarding a request to a backend and receiving response headers back before failing the request
-  responseHeaderTimeout: 500ms
+  responseHeaderTimeout: 30s
   # -- How often (in milliseconds) the interceptor does a full refresh of its endpoints cache. The interceptor will also use Kubernetes events to stay up-to-date with the endpoints cache changes. This duration is the maximum time it will take to see changes to the endpoints.
   endpointsCachePollingIntervalMS: 20000
   # -- Whether or not the interceptor should force requests to use HTTP/2
@@ -179,7 +179,7 @@ interceptor:
   # -- The maximum number of idle connections allowed in the interceptor's in-memory connection pool. Set to 0 to indicate no limit
   maxIdleConns: 100
   # -- The timeout after which any idle connection is closed and removed from the interceptor's in-memory connection pool.
-  idleConnTimeout: 90s
+  idleConnTimeout: 10m
   # -- The maximum amount of time the interceptor will wait for a TLS handshake. Set to zero to indicate no timeout.
   tlsHandshakeTimeout: 10s
   # -- Special handling for responses with "Expect: 100-continue" response headers. see https://pkg.go.dev/net/http#Transport under the 'ExpectContinueTimeout' field for more details
@@ -240,8 +240,8 @@ interceptor:
     # -- The maximum number of replicas that can be unavailable for the interceptor
     maxUnavailable: 1
 
-  # custom headers added to requests and responses passing through the interceptor and/or kedify-proxy
-  # for multiple headers, separate them with a comma, e.g. h1:v1,h2:v2
+  # # custom headers added to requests and responses passing through the interceptor and/or kedify-proxy
+  # # for multiple headers, separate them with a comma, e.g. h1:v1,h2:v2
   # customHeaders:
   #   interceptor:
   #     request: "X-Kedify-Interceptor:True"
@@ -249,6 +249,12 @@ interceptor:
   #   kedifyProxy:
   #     request: "X-Kedify-Proxy:True"
   #     response: "X-Kedify-Proxy:True"
+  #
+  # # additional tuning parameters for envoy proxy
+  # envoy:
+  #   listener:
+  #     tcpBacklogSize: 128
+  #   perConnectionBufferLimitBytes: 1048576
 
 # configuration for the images to use for each component
 images:


### PR DESCRIPTION
adding configuration options for envoy:
* [listener `tcp_backlog_size`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/listener/v3/listener.proto#:~:text=by%20this%20listener.-,tcp_backlog_size,-(UInt32Value)%20The) - defaults to kernel param `net.core.somaxconn` or 128. It is not permitted to configure this to less than 128.
* [listener `per_connection_buffer_limit_bytes`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/listener/v3/listener.proto#:~:text=in%20this%20field.-,per_connection_buffer_limit_bytes,-(UInt32Value)%20Soft) - defaults to 1MiB and can be set to overwrite the buffer limit for read and write on downstream
* [cluster `per_connection_buffer_limit_bytes`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#:~:text=will%20be%20used.-,per_connection_buffer_limit_bytes,-(UInt32Value)%20Soft) - defaults to 1MiB and can be set to overwrite the buffer limit for read and write on upstream

