### PR TITLE
kedify-proxy: overload manager config

### DIFF
--- a/kedify-proxy/Chart.yaml
+++ b/kedify-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kedify-proxy
 description: A Helm chart for Kedify proxy
 type: application
-version: v0.0.1
+version: v0.0.2
 
 # This is the version number of the application being deployed. Kedify proxy is based on Envoy proxy so it is a version of 
 # Envoy proxy container image (envoyproxy/envoy)

--- a/kedify-proxy/files/envoy-config.yaml
+++ b/kedify-proxy/files/envoy-config.yaml
@@ -76,3 +76,12 @@ static_resources:
               socket_address:
                 address: "{{ .Values.config.kedifyEnvoyCP }}.{{ .Values.config.kedaNamespace }}.svc.{{ .Values.config.clusterDomain }}"
                 port_value: {{ .Values.config.kedifyEnvoyCPPort }}
+{{- if and .Values.config.overloadManager .Values.config.overloadManager.enabled }}
+overload_manager:
+  refresh_interval: {{ .Values.config.overloadManager.refreshInterval }}
+  resource_monitors:
+    - name: envoy.resource_monitors.global_downstream_max_connections
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+        max_active_downstream_connections: {{ .Values.config.overloadManager.maxActiveDownstreamConnections }}
+{{- end }}

--- a/kedify-proxy/files/envoy-config.yaml
+++ b/kedify-proxy/files/envoy-config.yaml
@@ -76,7 +76,7 @@ static_resources:
               socket_address:
                 address: "{{ .Values.config.kedifyEnvoyCP }}.{{ .Values.config.kedaNamespace }}.svc.{{ .Values.config.clusterDomain }}"
                 port_value: {{ .Values.config.kedifyEnvoyCPPort }}
-{{- if and .Values.config.overloadManager .Values.config.overloadManager.enabled }}
+{{- if (.Values.config.overloadManager).enabled }}
 overload_manager:
   refresh_interval: {{ .Values.config.overloadManager.refreshInterval }}
   resource_monitors:

--- a/kedify-proxy/values.yaml
+++ b/kedify-proxy/values.yaml
@@ -27,6 +27,16 @@ config:
   kedifyEnvoyCPPort: 5678
   # -- port on kedify interceptor (`.config.kedifyEnvoyCP` host) where metrics from envoy data planes will be sent
   kedifyMetricsSinkPort: 9901
+  # -- overloadManager static configuration
+  # by default, the overload manager is disabled which means that there is no limit on active downstream connections
+  # NOTE: changing any values here restarts all kedify-proxy instances
+  overloadManager:
+    # -- enabled toggle to enable/disable overload manager
+    enabled: false
+    # -- refresh interval for the overload manager
+    refreshInterval: 0.25s
+    # -- max active downstream connections
+    maxActiveDownstreamConnections: 10000
 
 pod:
   # -- custom annotations that should be added to the Kedify proxy pod


### PR DESCRIPTION
configuration for overload manager for kedify-proxy envoy. This fixes the warning from envoy startup:
```
[warning][main] [source/server/server.cc:959] There is no configured limit to the number of allowed active downstream connections. Configure a limit in `envoy.resource_monitors.global_downstream_max_connections` resource monitor.
```
