### PR TITLE
kedify-agent: make schema validation optional

### DIFF
--- a/kedify-agent/values.schema.json
+++ b/kedify-agent/values.schema.json
@@ -1,17 +1,29 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "schema for values.yaml for kedify agent helm chart",
-  "$ref": "#/defs/Top-lvl",
   "defs": {
     "Top-lvl": {
       "properties": {
+        "disableSchemaValidation": {
+          "type": "boolean",
+          "default": false
+        },
         "agent": {
           "$ref": "#/defs/Agent"
         }
       },
       "required": [
         "agent"
-      ]
+      ],
+      "if": {
+        "properties": {
+          "disableSchemaValidation": { "const": false }
+        },
+        "required": ["disableSchemaValidation"]
+      },
+      "then": {
+        "required": ["agent"]
+      }
     },
     "Agent": {
       "properties": {
@@ -68,6 +80,18 @@
         "orgId"
       ]
     }
-  }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "disableSchemaValidation": { "const": false }
+        },
+        "required": ["disableSchemaValidation"]
+      },
+      "then": {
+        "$ref": "#/defs/Top-lvl"
+      }
+    }
+  ]
 }
-

--- a/kedify-agent/values.yaml
+++ b/kedify-agent/values.yaml
@@ -1,5 +1,8 @@
 clusterName: "cluster-1"
 
+# when set to true, the schema validation will be disabled
+disableSchemaValidation: false 
+
 agent:
   replicas: 1
 


### PR DESCRIPTION
The schema validation checks for proper `apiKey` and `orgId`
```
- agent.apiKey: String length must be greater than or equal to 10
- agent.apiKey: Does not match pattern '^kfy_[a-z0-9]*$'
- agent.orgId: Does not match format 'uuid'
```

For gitops deployments, it is possible to disable it globally via flag for all helm charts but sometimes that is not desirable. This introduces another option to disable schema validation only for this helm chart by setting `--set disableSchemaValidation=false`

closes: https://github.com/kedify/charts/pull/143
