### PR TITLE
http-add-on: release v0.10.0-3

### DIFF
--- a/http-add-on/Chart.yaml
+++ b/http-add-on/Chart.yaml
@@ -11,12 +11,12 @@ kubeVersion: ">=v1.23.0-0"
 # to the chart and its templates, including the app version. This is incremented at chart release time and does not need
 # to be included in any PRs to main.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v0.10.0-1
+version: v0.10.0-3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: v0.10.0-1
+appVersion: v0.10.0-3
 home: https://github.com/kedacore/http-add-on
 sources:
   - https://github.com/kedacore/http-add-on

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -266,7 +266,7 @@ images:
   # the build for the latest commit to the `main` branch,
   # and you can target any other commit with `sha-<GIT_SHA[0:7]>`
   # -- Image tag for the http add on. This tag is applied to the images listed in `images.operator`, `images.interceptor`, and `images.scaler`. Optional, given app version of Helm chart is used by default
-  tag: v0.10.0-1
+  tag: v0.10.0-3
   # -- Image name for the operator image component
   operator: ghcr.io/kedify/http-add-on-operator
   # -- Image name for the interceptor image component


### PR DESCRIPTION
# Chart v0.10.0-3 CHANGELOG:
* interceptor: envoy connection buffers and backlog config with higher defaults ([#144](https://github.com/kedify/charts/pull/144))
* interceptor: clarify configurable timeouts ([#138](https://github.com/kedify/charts/pull/138))
* http-add-on: exposing metrics port on interceptor deployment ([#136](https://github.com/kedify/charts/pull/136))
* interceptor: explicit int conversion for large envoy values ([#149](https://github.com/kedify/charts/pull/149))
* interceptor: increase default cold-start timeout to 20 min ([#150](https://github.com/kedify/charts/pull/150))
* image version bump to v0.10.0-3

# Image v0.10.0-3 CHANGELOG:
## Features:
* envoy xDS: config for listener connection buffers and backlog size

## Fixes:
* envoy stats sink: add HSO hooks before informers start
* envoy stats sink: group metrics by envoy deployed namespace
* envoy stats sink: istio peer IP from x-forwarded-for header
* envoy stats sink: LRU cache for endpoints IP to Namespace mapping