### PR TITLE
kedify-proxy: preStop hook with active connection check

### DIFF
--- a/kedify-proxy/templates/envoy-deployment.yaml
+++ b/kedify-proxy/templates/envoy-deployment.yaml
@@ -48,10 +48,34 @@ spec:
                   - /bin/bash
                   - -c
                   - |
-                    echo "Gracefully shutting down kedify-proxy"
+                    function log() {
+                      echo "[$(date -u +'%Y-%m-%d %T.%3N')][1][info][prestop-hook] $1" > /proc/1/fd/1
+                    }
+                    log "Gracefully shutting down kedify-proxy"
                     exec 3<>/dev/tcp/localhost/{{ .Values.service.adminPort }}
-                    echo -e 'POST /healthcheck/fail HTTP/1.1\r\nHost: localhost\r\nContent-Length:0\r\n\r\n' >&3
-                    sleep {{ .Values.pod.preStopHookWaitSeconds }}
+                    echo -e 'POST /healthcheck/fail HTTP/1.1\r\nHost: preStopHook\r\nContent-Length:0\r\nConnection: close\r\n\r\n' >&3
+                    response=$(cat <&3)
+
+                    timeout={{ .Values.pod.terminationGracePeriodSeconds }}
+                    interval=1
+                    elapsed=0
+
+                    while [[ "$elapsed" -lt "$timeout" ]]; do
+                      exec 3<>/dev/tcp/localhost/{{ .Values.service.adminPort }}
+                      echo -e 'GET /stats?filter=http.kedify-proxy.downstream_cx_active HTTP/1.1\r\nHost: preStopHook\r\nConnection: close\r\n\r\n' >&3
+                      response=$(cat <&3)
+                      active_connections=$(echo "$response" | awk '/http.kedify-proxy.downstream_cx_active:/{print $2}')
+                      log "Try $elapsed/$timeout; active connections: $active_connections"
+                      if [[ "$active_connections" -eq 0 ]]; then
+                        log "No active connections, terminating in {{ .Values.pod.preStopHookWaitSeconds }} seconds"
+                        sleep {{ .Values.pod.preStopHookWaitSeconds }}
+                        exit 0
+                      fi
+                      sleep $interval
+                      elapsed=$((elapsed + interval))
+                    done
+                    log "Timeout reached with active connections: $active_connections, terminating anyway"
+                    exit 1
           env:
             - name: ENVOY_UID
               value: {{ .Values.pod.containerSecurityContext.runAsUser | quote }}

--- a/kedify-proxy/values.yaml
+++ b/kedify-proxy/values.yaml
@@ -55,22 +55,20 @@ pod:
     httpGet:
       path: /ready
       port: admin
-    periodSeconds: 1
-    initialDelaySeconds: 1
-    failureThreshold: 3
+    periodSeconds: 2
+    initialDelaySeconds: 5
+    failureThreshold: 5
   # -- custom timeouts and thresholds for readiness probe
   readinessProbe:
     httpGet:
       path: /ready
       port: admin
-    # exec:
-    #   command: ["true"]
     periodSeconds: 1
     initialDelaySeconds: 1
     failureThreshold: 2
-  # -- custom timeout for graceful shutdown, should be larger than: readiness probe threshold * period
+  # -- custom timeout for graceful shutdown, should be smaller or equal to terminationGracePeriodSeconds
   preStopHookWaitSeconds: 5
-  # -- custom timeout for pod termination, should be larger than: preStopHookWaitSeconds + (readiness probe threshold * period)
+  # -- custom timeout for pod termination, should be larger or equal to preStopHookWaitSeconds
   terminationGracePeriodSeconds: 30
 
 deployment:


### PR DESCRIPTION
This PR makes the preStop hook aware of the currently active connections in the envoy. When a particular envoy pod goes to a terminating state, the preStop hook triggers envoy endpoint to ensure it fails the readiness probe and is excluded from traffic routing. Periodic check for active connections with a configurable timeout ensures envoy is not terminated prematurely before all active connections get a chance to finish gracefully.

<details>

<summary>sample logs</summary>

```
[2025-04-08 18:06:32.219][1][info][prestop-hook] Gracefully shutting down kedify-proxy
[2025-04-08 18:06:32.230][1][info][prestop-hook] Try 0/30; active connections: 139
[2025-04-08 18:06:33.240][1][info][prestop-hook] Try 1/30; active connections: 79
[2025-04-08 18:06:34.252][1][info][prestop-hook] Try 2/30; active connections: 55
[2025-04-08 18:06:35.266][1][info][prestop-hook] Try 3/30; active connections: 55
[2025-04-08 18:06:36.279][1][info][prestop-hook] Try 4/30; active connections: 55
[2025-04-08 18:06:37.292][1][info][prestop-hook] Try 5/30; active connections: 55
[2025-04-08 18:06:38.306][1][info][prestop-hook] Try 6/30; active connections: 55
[2025-04-08 18:06:39.319][1][info][prestop-hook] Try 7/30; active connections: 55
[2025-04-08 18:06:40.330][1][info][prestop-hook] Try 8/30; active connections: 55
[2025-04-08 18:06:41.342][1][info][prestop-hook] Try 9/30; active connections: 55
[2025-04-08 18:06:42.356][1][info][prestop-hook] Try 10/30; active connections: 55
[2025-04-08 18:06:43.367][1][info][prestop-hook] Try 11/30; active connections: 0
[2025-04-08 18:06:43.369][1][info][prestop-hook] No active connections, terminating in 5 seconds
[2025-04-08 18:06:48.382][1][warning][main] [source/server/server.cc:928] caught ENVOY_SIGTERM
[2025-04-08 18:06:48.382][1][info][main] [source/server/server.cc:1069] shutting down server instance
[2025-04-08 18:06:48.382][1][info][main] [source/server/server.cc:1009] main dispatch loop exited
[2025-04-08 18:06:48.397][1][warning][config] [./source/extensions/config_subscription/grpc/grpc_stream.h:188] StreamListeners gRPC config stream to xds_cluster closed: 13,
[2025-04-08 18:06:48.397][1][info][main] [source/server/server.cc:1061] exiting
```

</details>

Also, this makes the default liveness probes less aggressive to not terminate busy envoys prematurely.