### PR TITLE
kedify-proxy: release v0.0.2

### DIFF
--- a/kedify-proxy/Chart.yaml
+++ b/kedify-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kedify-proxy
 description: A Helm chart for Kedify proxy
 type: application
-version: v0.0.1
+version: v0.0.2
 
 # This is the version number of the application being deployed. Kedify proxy is based on Envoy proxy so it is a version of 
 # Envoy proxy container image (envoyproxy/envoy)


### PR DESCRIPTION
# Chart v0.0.2 CHANGELOG:
* kedify-proxy: preStop hook with active connection check ([#151](https://github.com/kedify/charts/pull/151))
* kedify-proxy: overload manager config ([#145](https://github.com/kedify/charts/pull/145))
