### PR TITLE
kedify-agent: rbac to watch, list deployments clusterwide for kedify-proxy installs

### DIFF
--- a/kedify-agent/templates/rbacs/can-install-kedify-proxy.yaml
+++ b/kedify-agent/templates/rbacs/can-install-kedify-proxy.yaml
@@ -25,6 +25,8 @@ rules:
   - deployments
   verbs:
   - create
+  - watch
+  - list
 - apiGroups:
   - apps
   resources:


### PR DESCRIPTION
when performing an upgrade of `kedify-proxy` helm chart, it's possible to get to a situation where `kedify-agent` throws the following error periodically
```
E0409 10:21:39.858684       1 reflector.go:158] "Unhandled Error" err="k8s.io/client-go@v0.31.1/tools/cache/reflector.go:243: Failed to watch *v1.Deployment: unknown (get deployments.apps)" logger="UnhandledError"
```

The https://github.com/kedify/charts/pull/141 tried to fix it by adding missing RBAC but `WATCH` and `LIST` methods don't work with `resourceName` which is present on that `ClusterRole` for `deployments` section. This adds both verbs into `ClusterRole` not restricted by any `resourceName`. The reason is the controller-runtime kube client spins up informer cache on demand when a resource is accessed which needs both `WATCH` and `LIST` RBAC.
