### PR TITLE
interceptor: maintenance page config

### DIFF
--- a/http-add-on/templates/interceptor/deployment.yaml
+++ b/http-add-on/templates/interceptor/deployment.yaml
@@ -120,6 +120,11 @@ spec:
         - name: KEDIFY_PROXY_PER_CONNECTION_BUFFER_LIMIT_BYTES
           value: "{{ int .Values.interceptor.envoy.perConnectionBufferLimitBytes }}"
         {{- end }}
+        - name: KEDIFY_DEFAULT_MAINTENANCE_PAGE
+          value: |
+            {{ .Values.interceptor.maintenancePage.body }}
+        - name: KEDIFY_DEFAULT_MAINTENANCE_PAGE_RESPONSE_CODE
+          value: "{{ .Values.interceptor.maintenancePage.responseStatusCode }}"
         {{- range .Values.interceptor.additionalEnvVars }}
         - name: "{{ .name }}"
           value: "{{ .value }}"

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -268,6 +268,13 @@ interceptor:
   #   listener:
   #     tcpBacklogSize: 128
   #   perConnectionBufferLimitBytes: 1048576
+  # -- Maintenance page configuration for the interceptor
+  maintenancePage:
+    # -- The HTML body displayed when maintenance mode for a certain application is enabled, limited to 256 KiB
+    body: |
+      Service is temporarily under maintenance. Please try again later.
+    # -- The HTTP status code to return when maintenance mode for a certain application is enabled
+    responseStatusCode: 503
 
 # configuration for the images to use for each component
 images:


### PR DESCRIPTION
When the `ScaledObject` has `kedify-http` scaler and the trigger metadata contains
```yaml
spec:
  triggers:
  - type: kedify-http
    metadata:
      maintenancePageEnabled: "true"
```
The traffic is served directly by the `interceptor` and http metrics for the target are discarded by the `scaler`. The `/queue` endpoint on the `interceptor` will still show the values but `scaler` replaces the value with `0` and sets `active` status to `false`.

The values `interceptor.maintenancePage.body` and `interceptor.maintenancePage.responseStatusCode` can be used to configure different default maintenance page behavior. These can be further overwritten by either inlining directly on the `ScaledObject` as
```yaml
spec:
  triggers:
  - type: kedify-http
    metadata:
      maintenancePageEnabled: "true"
      maintenancePageBody: |-
        alternative maintenance page message
      maintenancePageStatusCode: "505"
```
or referenced per namespace in a `ConfigMap` with the same keys `maintenancePageBody` / `maintenancePageStatusCode` and then setting `maintenancePageConfigMapRef` on trigger metadata instead of inlining directly.
```yaml
spec:
  triggers:
  - type: kedify-http
    metadata:
      maintenancePageEnabled: "true"
      maintenancePageConfigMapRef: maintenance-page-cm
```

The precedence order of configured maintenance pages are (highest to lowest)
* inlined >> namespaced >> default