### PR TITLE
interceptor: parameters for kedify-proxy envoy circuit breakers

### DIFF
--- a/http-add-on/templates/interceptor/deployment.yaml
+++ b/http-add-on/templates/interceptor/deployment.yaml
@@ -125,6 +125,22 @@ spec:
             {{ .Values.interceptor.maintenancePage.body }}
         - name: KEDIFY_DEFAULT_MAINTENANCE_PAGE_RESPONSE_CODE
           value: "{{ .Values.interceptor.maintenancePage.responseStatusCode }}"
+        {{- if ((.Values.interceptor.envoy).upstreamRateLimiting).maxConnections }}
+        - name: KEDA_HTTP_PROXY_MAX_UPSTREAM_CONNECTIONS
+          value: "{{ .Values.interceptor.envoy.upstreamRateLimiting.maxConnections }}"
+        {{- end }}
+        {{- if ((.Values.interceptor.envoy).upstreamRateLimiting).maxPendingRequests }}
+        - name: KEDA_HTTP_PROXY_MAX_UPSTREAM_PENDING_REQUESTS
+          value: "{{ .Values.interceptor.envoy.upstreamRateLimiting.maxPendingRequests }}"
+        {{- end }}
+        {{- if ((.Values.interceptor.envoy).upstreamRateLimiting).maxRequests }}
+        - name: KEDA_HTTP_PROXY_MAX_UPSTREAM_REQUESTS
+          value: "{{ .Values.interceptor.envoy.upstreamRateLimiting.maxRequests }}"
+        {{- end }}
+        {{- if ((.Values.interceptor.envoy).upstreamRateLimiting).maxRetries }}
+        - name: KEDA_HTTP_PROXY_MAX_UPSTREAM_RETRIES
+          value: "{{ .Values.interceptor.envoy.upstreamRateLimiting.maxRetries }}"
+        {{- end }}
         {{- range .Values.interceptor.additionalEnvVars }}
         - name: "{{ .name }}"
           value: "{{ .value }}"

--- a/http-add-on/templates/interceptor/deployment.yaml
+++ b/http-add-on/templates/interceptor/deployment.yaml
@@ -126,20 +126,20 @@ spec:
         - name: KEDIFY_DEFAULT_MAINTENANCE_PAGE_RESPONSE_CODE
           value: "{{ .Values.interceptor.maintenancePage.responseStatusCode }}"
         {{- if ((.Values.interceptor.envoy).upstreamRateLimiting).maxConnections }}
-        - name: KEDA_HTTP_PROXY_MAX_UPSTREAM_CONNECTIONS
-          value: "{{ .Values.interceptor.envoy.upstreamRateLimiting.maxConnections }}"
+        - name: KEDIFY_HTTP_PROXY_MAX_UPSTREAM_CONNECTIONS
+          value: "{{ int .Values.interceptor.envoy.upstreamRateLimiting.maxConnections }}"
         {{- end }}
         {{- if ((.Values.interceptor.envoy).upstreamRateLimiting).maxPendingRequests }}
-        - name: KEDA_HTTP_PROXY_MAX_UPSTREAM_PENDING_REQUESTS
-          value: "{{ .Values.interceptor.envoy.upstreamRateLimiting.maxPendingRequests }}"
+        - name: KEDIFY_HTTP_PROXY_MAX_UPSTREAM_PENDING_REQUESTS
+          value: "{{ int .Values.interceptor.envoy.upstreamRateLimiting.maxPendingRequests }}"
         {{- end }}
         {{- if ((.Values.interceptor.envoy).upstreamRateLimiting).maxRequests }}
-        - name: KEDA_HTTP_PROXY_MAX_UPSTREAM_REQUESTS
-          value: "{{ .Values.interceptor.envoy.upstreamRateLimiting.maxRequests }}"
+        - name: KEDIFY_HTTP_PROXY_MAX_UPSTREAM_REQUESTS
+          value: "{{ int .Values.interceptor.envoy.upstreamRateLimiting.maxRequests }}"
         {{- end }}
         {{- if ((.Values.interceptor.envoy).upstreamRateLimiting).maxRetries }}
-        - name: KEDA_HTTP_PROXY_MAX_UPSTREAM_RETRIES
-          value: "{{ .Values.interceptor.envoy.upstreamRateLimiting.maxRetries }}"
+        - name: KEDIFY_HTTP_PROXY_MAX_UPSTREAM_RETRIES
+          value: "{{ int .Values.interceptor.envoy.upstreamRateLimiting.maxRetries }}"
         {{- end }}
         {{- range .Values.interceptor.additionalEnvVars }}
         - name: "{{ .name }}"

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -268,6 +268,23 @@ interceptor:
   #   listener:
   #     tcpBacklogSize: 128
   #   perConnectionBufferLimitBytes: 1048576
+  #
+  # # configuration for kedify-proxy envoy rate limiting
+  #   upstreamRateLimiting:
+  #     # -- The maximum number of connections that Envoy will make to the upstream cluster.
+  #     # If not specified, the default is 8192.
+  #     maxConnections: 8192
+  #     # -- The maximum number of requests per second that the interceptor will allow for upstream requests
+  #     # The maximum number of parallel requests that Envoy will make to the upstream cluster.
+  #     # If not specified, the default is 8192. This limit does not apply to non-HTTP traffic.
+  #     maxRequests: 8192
+  #     # -- The maximum number of pending requests that Envoy will allow to the upstream cluster.
+  #     # If not specified, the default is 8192. This limit is applied as a connection limit for non-HTTP traffic.
+  #     maxPendingRequests: 8192
+  #     # -- The maximum number of parallel retries that Envoy will allow to the upstream cluster.
+  #     # If not specified, the default is 3.
+  #     maxRetries: 3
+
   # -- Maintenance page configuration for the interceptor
   maintenancePage:
     # -- The HTML body displayed when maintenance mode for a certain application is enabled, limited to 256 KiB

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -270,6 +270,7 @@ interceptor:
   #   perConnectionBufferLimitBytes: 1048576
   #
   # # configuration for kedify-proxy envoy rate limiting
+  # # https://www.envoyproxy.io/docs/envoy/latest/configuration/upstream/cluster_manager/cluster_circuit_breakers#circuit-breaking
   #   upstreamRateLimiting:
   #     # -- The maximum number of connections that Envoy will make to the upstream cluster.
   #     # If not specified, the default is 8192.


### PR DESCRIPTION
Parameters for `kedify-proxy` circuit breakers in the envoy config set by the `interceptor` for each autoscaled application globally. These options can serve as a protection from overloading the autoscaled application during rapid traffic spikes.