### PR TITLE
interceptor: fix autoscaling defaults with memory request 256Mi

### DIFF
--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -118,7 +118,7 @@ scaler:
       memory: 512Mi
     requests:
       cpu: 250m
-      memory: 20Mi
+      memory: 256Mi
   # -- Annotations to be added to the scaler pods
   podAnnotations: {}
 
@@ -154,7 +154,7 @@ interceptor:
     # -- The minimum number of interceptor replicas that should ever be running
     min: 1
     # -- The maximum number of interceptor replicas that should ever be running
-    max: 50
+    max: 3
     # -- The maximum time the interceptor should wait during cold start for an HTTP request to reach a backend before it is considered a failure
     waitTimeout: 20m
 


### PR DESCRIPTION
https://github.com/kedify/charts/pull/156 introduced a bug making the interceptor autoscaling trigger too much with the default parameters and scales to 50 very fast even on idle setups.
```
$ k get hpa -nkeda
NAME                                     REFERENCE                                  TARGETS                         MINPODS   MAXPODS
REPLICAS   AGE
keda-hpa-keda-add-ons-http-interceptor   Deployment/keda-add-ons-http-interceptor   cpu: 1%/75%, memory: 118%/90%   1         50
50         177m
```
The default memory requests were very low - 20Mi. Also having 50 interceptors would rarely be a good idea as it's only used for metric aggregation and cached cold-starts.