### PR TITLE
interceptor: cold-start waiting page configuration

### DIFF
--- a/http-add-on/templates/interceptor/deployment.yaml
+++ b/http-add-on/templates/interceptor/deployment.yaml
@@ -122,9 +122,16 @@ spec:
         {{- end }}
         - name: KEDIFY_DEFAULT_MAINTENANCE_PAGE
           value: |
-            {{ .Values.interceptor.maintenancePage.body }}
+{{ .Values.interceptor.maintenancePage.body | indent 12 }}
         - name: KEDIFY_DEFAULT_MAINTENANCE_PAGE_RESPONSE_CODE
           value: "{{ .Values.interceptor.maintenancePage.responseStatusCode }}"
+        - name: KEDIFY_DEFAULT_COLD_START_WAITING_PAGE
+          value: |
+{{ .Values.interceptor.coldStartWaitingPage.body | indent 12 }}
+        - name: KEDIFY_DEFAULT_COLD_START_WAITING_PAGE_RESPONSE_CODE
+          value: "{{ .Values.interceptor.coldStartWaitingPage.responseStatusCode }}"
+        - name: KEDIFY_DEFAULT_COLD_START_WAITING_PAGE_RETRY_AFTER
+          value: "{{ .Values.interceptor.coldStartWaitingPage.retryAfter }}"
         {{- if ((.Values.interceptor.envoy).upstreamRateLimiting).maxConnections }}
         - name: KEDIFY_HTTP_PROXY_MAX_UPSTREAM_CONNECTIONS
           value: "{{ int .Values.interceptor.envoy.upstreamRateLimiting.maxConnections }}"

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -289,10 +289,20 @@ interceptor:
   # -- Maintenance page configuration for the interceptor
   maintenancePage:
     # -- The HTML body displayed when maintenance mode for a certain application is enabled, limited to 256 KiB
-    body: |
+    body: |-
       Service is temporarily under maintenance. Please try again later.
     # -- The HTTP status code to return when maintenance mode for a certain application is enabled
     responseStatusCode: 503
+
+  # -- Cold start waiting page configuration defaults for the interceptor
+  coldStartWaitingPage:
+    # -- The HTML body displayed when the application has cold-start waiting page enabled, limited to 256 KiB
+    body: |-
+      Service is starting. Please try again later.
+    # -- The HTTP status code to return when the application has cold-start waiting page enabled
+    responseStatusCode: 503
+    # -- Value in the `Retry-After` header to return when the application has cold-start waiting page enabled
+    retryAfter: 60s 
 
 # configuration for the images to use for each component
 images:


### PR DESCRIPTION
When the `ScaledObject` has `kedify-http` scaler and the trigger metadata contains
```yaml
spec:
  triggers:
  - type: kedify-http
    metadata:
      coldStartWaitingPage: "true"
```
Then during the cold-start `interceptor` no longer holds the proxied request but instead responds directly with static page, the http metrics are still accounted for.

The values `interceptor.coldStartWaitingPage.body`, `interceptor.coldStartWaitingPage.responseStatusCode`, and `interceptor.coldStartWaitingPage.retryAfter` can be used to configure different default cold-start waiting page behavior. These can be further overwritten by either inlining directly on the `ScaledObject` as
```yaml
spec:
  triggers:
  - type: kedify-http
    metadata:
      coldStartWaitingPageEnabled: "true"
      coldStartWaitingPageBody: |-
        alternative cold-start waiting page message
      coldStartWaitingPageStatusCode: "505"
      coldStartWaitingPageRetryAfter: "60s"
```
or referenced per namespace in a `ConfigMap` with the same keys `coldStartWaitingPageBody` / `coldStartWaitingPageStatusCode` / `coldStartWaitingPageRetryAfter`and then setting `coldStartWaitingPageConfigMapRef` on trigger metadata instead of inlining directly.
```yaml
spec:
  triggers:
  - type: kedify-http
    metadata:
      coldStartWaitingPageEnabled: "true"
      coldStartWaitingPageConfigMapRef: waiting-page-cm
```
The config maps for `maintenancePage` (https://github.com/kedify/charts/pull/157) and `coldStartWaitingPage` can be the same.

The precedence order of configured cold-start waiting pages are (highest to lowest):
* inlined >> namespaced >> default