### PR TITLE
kedify-proxy: envoy delta ads

### DIFF
--- a/kedify-proxy/files/envoy-config.yaml
+++ b/kedify-proxy/files/envoy-config.yaml
@@ -24,20 +24,16 @@ admin:
       address: 0.0.0.0
       port_value: {{ .Values.service.adminPort }}
 dynamic_resources:
+  ads_config:
+    api_type: DELTA_GRPC
+    transport_api_version: V3
+    grpc_services:
+    - envoy_grpc:
+        cluster_name: xds_cluster
   lds_config:
-    api_config_source:
-      api_type: GRPC
-      transport_api_version: V3
-      grpc_services:
-      - envoy_grpc:
-          cluster_name: xds_cluster
+    ads: {}
   cds_config:
-    api_config_source:
-      api_type: GRPC
-      transport_api_version: V3
-      grpc_services:
-      - envoy_grpc:
-          cluster_name: xds_cluster
+    ads: {}
 static_resources:
   clusters:
   - name: kedify_metrics_service


### PR DESCRIPTION
When there are quick changes in both listeners as well as clusters, kedify-proxy sometimes rejects the config as invalid. Kedify envoy control-plane has a built-in retry mechanism and the config is eventually synced, but this results in a number of unnecessary errors:
```
[2025-02-12 12:02:43.606][1][warning][config] [source/extensions/config_subscription/grpc/grpc_subscription_impl.cc:138] gRPC config for type.googleapis.com/envoy.config.listener.v3.Listener rejected: Error adding/updating listener(s) kedify-proxy: route: unknown cluster 'default/http-server-4' kedify-proxy-tls: route: unknown cluster 'default/http-server-4'
```
This PR brings two changes to the envoy bootstrap config:
1) using [ADS](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/discovery/v3/ads.proto) for single multiplexed grpc stream for configs
2) changing `SotW` to `delta` [for config changes](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/operations/dynamic_configuration#delta-grpc-xds)