### PR TITLE
kedify-agent: fix SO http-add-on subchart dependency for the all-in-one installation

### DIFF
--- a/kedify-agent/Chart.lock
+++ b/kedify-agent/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 2.17.1-0
 - name: keda-add-ons-http
   repository: https://kedify.github.io/charts
-  version: v0.10.0-7
-digest: sha256:e1d9c88254eaa979701b67d060921c258720937405a4fb5106a1d46d765f1049
-generated: "2025-05-19T12:02:30.973670364+02:00"
+  version: v0.10.0-10
+digest: sha256:1efb5d4eb6010e06655b56167126432486776b7ab6e443806b561ee0f4994c52
+generated: "2025-06-02T16:50:29.014093+02:00"

--- a/kedify-agent/Chart.yaml
+++ b/kedify-agent/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
     condition: keda.enabled
   - name: keda-add-ons-http
     repository: https://kedify.github.io/charts
-    version: v0.10.0-7
+    version: v0.10.0-10
     condition: kedaAddOnsHttp.enabled,keda-add-ons-http.enabled
 home: https://github.com/kedify/charts
 sources:

--- a/kedify-agent/values.yaml
+++ b/kedify-agent/values.yaml
@@ -189,7 +189,17 @@ agent:
 keda:
   # for all available values, check: https://github.com/kedify/charts/blob/main/keda/values.yaml
   enabled: false
+  prometheus:
+    operator:
+      enabled: true
+    metricServer:
+      enabled: true
+    webhooks:
+      enabled: true
 
 keda-add-ons-http:
   # for all available values, check: https://github.com/kedify/charts/blob/main/http-add-on/values.yaml
   enabled: false
+  interceptor:
+    scaledObject:
+      waitForCrd: true


### PR DESCRIPTION
continuation of https://github.com/kedify/charts/pull/183 (the http-addon helm chart had to be released)

consuming the async job that creates crd & cr (SO)

