### PR TITLE
Multiarch image for kubectl tool

### DIFF
--- a/http-add-on/templates/interceptor/scaledobject/so-configmap.yaml
+++ b/http-add-on/templates/interceptor/scaledobject/so-configmap.yaml
@@ -20,7 +20,6 @@ data:
       labels:
         app.kubernetes.io/component: interceptor
         app.kubernetes.io/name: http-add-on
-        {{- include "keda-http-add-on.labels" . | indent 4 }}
     spec:
       minReplicaCount: {{ .Values.interceptor.replicas.min }}
       maxReplicaCount: {{ .Values.interceptor.replicas.max }}

--- a/http-add-on/templates/interceptor/scaledobject/so-job.yaml
+++ b/http-add-on/templates/interceptor/scaledobject/so-job.yaml
@@ -22,7 +22,7 @@ spec:
         app: create-interceptor-scaledobject
     spec:
       restartPolicy: Never
-      serviceAccountName: install-interceptor-scaledobject
+      serviceAccountName: install-interceptor-so
       securityContext:
         runAsUser: 1000
         runAsGroup: 2000
@@ -38,7 +38,7 @@ spec:
             path: interceptor-scaledobject.yaml
       initContainers:
       - name: wait-crds
-        image: "quay.io/giantswarm/docker-kubectl:1.29.2"
+        image: "ghcr.io/kedify/kubectl:v1.33.1"
         imagePullPolicy: IfNotPresent
         command:
         - sh
@@ -55,7 +55,7 @@ spec:
           done
       containers:
       - name: create-interceptor-scaledobject
-        image: "quay.io/giantswarm/docker-kubectl:1.29.2"
+        image: "ghcr.io/kedify/kubectl:v1.33.1"
         imagePullPolicy: IfNotPresent
         securityContext:
           readOnlyRootFilesystem: true

--- a/http-add-on/templates/interceptor/scaledobject/so-rbac.yaml
+++ b/http-add-on/templates/interceptor/scaledobject/so-rbac.yaml
@@ -28,8 +28,6 @@ rules:
   - patch
   - create
   - get
-  resourceNames:
-  - {{ .Chart.Name }}-interceptor
 - apiGroups:
   - apiextensions.k8s.io
   resources:

--- a/kedify-agent/templates/cr-install/cr-job.yaml
+++ b/kedify-agent/templates/cr-install/cr-job.yaml
@@ -37,7 +37,7 @@ spec:
             path: default-kedifyconfig.yaml
       initContainers:
       - name: wait-crds
-        image: "quay.io/giantswarm/docker-kubectl:1.29.2"
+        image: "ghcr.io/kedify/kubectl:v1.33.1"
         imagePullPolicy: IfNotPresent
         command:
         - sh
@@ -51,7 +51,7 @@ spec:
           done
       containers:
       - name: create-default-kedifyconfig
-        image: "quay.io/giantswarm/docker-kubectl:1.29.2"
+        image: "ghcr.io/kedify/kubectl:v1.33.1"
         imagePullPolicy: IfNotPresent
         securityContext:
           readOnlyRootFilesystem: true


### PR DESCRIPTION
Fixes #186 

- resourceNames restriction in rbac doesn't work for verb 'create'
- typo in service account
- multiarch images for kubectl tool