### PR TITLE
kedify-agent: rbac for kedify-proxy clusterwide

### DIFF
--- a/kedify-agent/templates/rbacs/can-install-kedify-proxy.yaml
+++ b/kedify-agent/templates/rbacs/can-install-kedify-proxy.yaml
@@ -105,24 +105,6 @@ rules:
   - secrets
   verbs:
   - create
-
-{{- if .Values.agent.kedifyProxy.clusterWide }}
----
-# counterintuitive, but 'clusterWide' => only 1 proxy in the {{ .Release.Namespace }} namespace (hence no need for global RBAC - using RoleBinding&ClusterRole)
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: kedify-agent-can-install-kedify-proxy
-  namespace: {{ .Release.Namespace }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: can-install-kedify-proxy
-subjects:
-- kind: ServiceAccount
-  name: kedify-agent
-  namespace: {{ .Release.Namespace }}
-{{- else }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -136,6 +118,5 @@ subjects:
 - kind: ServiceAccount
   name: kedify-agent
   namespace: {{ .Release.Namespace }}
-{{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Currently, the kedify-agent requires clusterwide RBAC for installation of kedify-proxy due to how the informers in the agent are initialized. For now addressing by providing more permissive RBAC.

Fixes https://github.com/kedify/charts/issues/165
