### PR TITLE
[http-addon] Allow to set custom image tag per component

### DIFF
--- a/http-add-on/templates/interceptor/deployment.yaml
+++ b/http-add-on/templates/interceptor/deployment.yaml
@@ -46,7 +46,7 @@ spec:
         {{- if .Values.logging.interceptor.stackTracesEnabled }}
         - "--zap-stacktrace-level=error"
         {{- end }}
-        image: "{{ .Values.images.interceptor }}:{{ .Values.images.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.images.interceptor }}:{{ coalesce .Values.images.tag .Values.pinnedImages.interceptor.tag .Chart.AppVersion }}"
         imagePullPolicy: '{{ .Values.interceptor.pullPolicy | default "Always" }}'
         name: "{{ .Chart.Name }}-interceptor"
         env:

--- a/http-add-on/templates/operator/deployment.yaml
+++ b/http-add-on/templates/operator/deployment.yaml
@@ -66,7 +66,7 @@ spec:
         {{- if .Values.logging.operator.stackTracesEnabled }}
         - "--zap-stacktrace-level=error"
         {{- end }}
-        image: "{{ .Values.images.operator }}:{{ .Values.images.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.images.operator }}:{{ coalesce .Values.images.tag .Values.pinnedImages.operator.tag .Chart.AppVersion }}"
         imagePullPolicy: '{{ .Values.operator.pullPolicy | default "Always" }}'
         name: "{{ .Chart.Name }}-operator"
         env:

--- a/http-add-on/templates/scaler/deployment.yaml
+++ b/http-add-on/templates/scaler/deployment.yaml
@@ -47,7 +47,7 @@ spec:
         {{- if .Values.logging.scaler.stackTracesEnabled }}
         - "--zap-stacktrace-level=error"
         {{- end }}
-        image: "{{ .Values.images.scaler }}:{{ .Values.images.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.images.scaler }}:{{ coalesce .Values.images.tag .Values.pinnedImages.scaler.tag .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.scaler.pullPolicy | default "Always" }}
         name: "{{ .Chart.Name }}-external-scaler"
         ports:

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -330,6 +330,16 @@ images:
     # -- Image tag for the Kube RBAC Proxy image component
     tag: v0.16.0
 
+# set of pinned images to use for the components
+# this is useful when you want to use a specific image version for a component
+pinnedImages:
+  interceptor:
+    tag: ""
+  scaler:
+    tag: ""
+  operator:
+    tag: ""
+
 rbac:
   # -- Install aggregate roles for edit and view
   aggregateToDefaultRoles: false


### PR DESCRIPTION
Use the [coalesce](https://helm.sh/docs/chart_template_guide/function_list/#coalesce) function to set a specific image tag per component [interceptor,scaler,operator].