### PR TITLE
kedify-agent: envoy cluster configuration

### DIFF
--- a/kedify-agent/templates/kedify-proxy-template-values-global.yaml
+++ b/kedify-agent/templates/kedify-proxy-template-values-global.yaml
@@ -15,3 +15,5 @@ data:
   envoy-config-route: |
     route:
 {{- toYaml .Values.agent.kedifyProxy.globalEnvoyConfigs.route | nindent 6 }}
+  envoy-config-cluster: |
+{{- toYaml .Values.agent.kedifyProxy.globalEnvoyConfigs.cluster | nindent 4 }}

--- a/kedify-agent/templates/kedify-proxy-template-values.yaml
+++ b/kedify-agent/templates/kedify-proxy-template-values.yaml
@@ -4,9 +4,12 @@
 {{- $allNamespaces := concat $namespacesValues $namespacesEnvoyConfigs | sortAlpha | uniq }}
 {{- range $ns := $allNamespaces }}
 {{- $values := index $.Values.agent.kedifyProxy.namespacedValues $ns | default dict }}
-{{- $envoyConfigsRoute := (index $.Values.agent.kedifyProxy.namespacedEnvoyConfigs $ns | default dict).route | default dict }}
+{{- $envoyConfig := index $.Values.agent.kedifyProxy.namespacedEnvoyConfigs $ns | default dict }}
+{{- $envoyConfigRoute := $envoyConfig.route | default dict }}
+{{- $envoyConfigCluster := $envoyConfig.cluster | default dict }}
 {{- $mergedValues := merge $values $.Values.agent.kedifyProxy.globalValues }}
-{{- $mergedEnvoyConfigsRoute := merge $envoyConfigsRoute $.Values.agent.kedifyProxy.globalEnvoyConfigs.route }}
+{{- $mergedEnvoyConfigRoute := merge $envoyConfigRoute $.Values.agent.kedifyProxy.globalEnvoyConfigs.route }}
+{{- $mergedEnvoyConfigCluster := merge $envoyConfigCluster $.Values.agent.kedifyProxy.globalEnvoyConfigs.cluster }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -25,6 +28,8 @@ data:
 {{- toYaml $mergedValues | nindent 4 }}
   envoy-config-route: |
     route:
-{{- toYaml $mergedEnvoyConfigsRoute | nindent 6 }}
+{{- toYaml $mergedEnvoyConfigRoute | nindent 6 }}
+  envoy-config-cluster: |
+{{- toYaml $mergedEnvoyConfigCluster | nindent 4 }}
 {{- end }}
 {{- end }}

--- a/kedify-agent/values.yaml
+++ b/kedify-agent/values.yaml
@@ -54,11 +54,15 @@ agent:
         format: plaintext
 
     # configuration options for kedify-proxy envoy fleet xDS
-    # see available options:
-    # https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#config-route-v3-routeaction
     globalEnvoyConfigs:
+      # see available options:
+      # https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#config-route-v3-routeaction
       route:
         idle_timeout: 3600s # 1 hour
+      # see available options:
+      # https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto
+      cluster:
+        lb_policy: ROUND_ROBIN
 
     # This is a namespaced helm template that will be used for desired namespaces (if `.agent.kedifyProxy.clusterWide` is off).
     # example of overriding the global template for namespaces 'prodNamespace' and 'testNamespace':


### PR DESCRIPTION
followup to https://github.com/kedify/charts/pull/188, allowing to specify `cluster` configuration snippets for envoy xDS.
https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto