### PR TITLE
http-add-on: EndpointSlices RBAC

### DIFF
--- a/http-add-on/templates/interceptor/rbac.yml
+++ b/http-add-on/templates/interceptor/rbac.yml
@@ -19,6 +19,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - services


### PR DESCRIPTION
http-add-on envoy control-plane by default leverages kube-dns for endpoint configuration along with [strict DNS](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/service_discovery#strict-dns). This means each envoy cluster has exactly one loadbalancer endpoint in the format
```
[target-svc].[namespace].svc.[cluster.local]
```
And the endpoints are discovered asynchronously through envoy internal DNS resolver.

Alternatively, it is possible to instruct the control-plane to use [Endpoint discovery service](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/service_discovery#endpoint-discovery-service-eds). In this case, http-add-on performs the IP discovery through `EndpoinSlices` Kubernetes API and sets the IP addresses of [`Ready`]( https://github.com/kubernetes/api/blob/v0.33.0/discovery/v1/types.go#L137-L144) endpoints directly. This setup results in more frequent envoy configuration updates but can improve routing for applications without readiness probes or graceful terminations. As a result, this needs RBAC for `EndpointSlices`.

This is configured per `ScaledObject` level through trigger metadata
```yaml
triggers:
  - type: kedify-http
    metadata:
      loadbalancing: eds
```
which is then propagated to `HTTPScaledObject` as an annotation
```yaml
annotations:
  http.kedify.io/envoy-endpoint-loadbalancing: eds
```