### PR TITLE
runAsUser 101 by default

### DIFF
--- a/kedify-agent/values.yaml
+++ b/kedify-agent/values.yaml
@@ -201,7 +201,7 @@ agent:
   securityContext:
     runAsNonRoot: true
     allowPrivilegeEscalation: false
-    readOnlyRootFilesystem: true
+    readOnlyRootFilesystem: false
     seccompProfile:
       type: RuntimeDefault
     capabilities:

--- a/kedify-proxy/templates/envoy-deployment.yaml
+++ b/kedify-proxy/templates/envoy-deployment.yaml
@@ -77,7 +77,7 @@ spec:
                     log "Timeout reached with active connections: $active_connections, terminating anyway"
                     exit 1
           env:
-            {{- if .Values.pod.containerSecurityContext.runAsUser }}
+            {{- if and .Values.pod.containerSecurityContext.runAsUser (not .Values.openshift) }}
             - name: ENVOY_UID
               value: {{ .Values.pod.containerSecurityContext.runAsUser | quote }}
             {{- end }}
@@ -87,7 +87,11 @@ spec:
 {{ tpl ($.Files.Get "files/envoy-config.yaml") $ | indent 16 }}
 
           securityContext:
+            {{- if .Values.openshift }}
+            {{- toYaml (omit .Values.pod.containerSecurityContext "runAsUser") | nindent 12 }}
+            {{- else }}
             {{- toYaml .Values.pod.containerSecurityContext | nindent 12 }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.httpPort }}

--- a/kedify-proxy/values.yaml
+++ b/kedify-proxy/values.yaml
@@ -47,6 +47,7 @@ pod:
   securityContext: {}
   # -- container-lvl securityContext [docs](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
   containerSecurityContext:
+    runAsUser: 101
     runAsNonRoot: true
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true


### PR DESCRIPTION
ad-hoc release to verify this:
```
helm template oci://ghcr.io/kedify/charts/kedify-proxy --version v0.0.4-uid
```

```
helm template oci://ghcr.io/kedify/charts/kedify-proxy --version v0.0.4-uid | grep runAsU
runAsUser: 101
```

```
helm template oci://ghcr.io/kedify/charts/kedify-proxy --version v0.0.4-uid --set openshift=true | grep runAsU
:tumbleweed:
```