### PR TITLE
http-addon: schema for values - tolerations should be object not string

### DIFF
--- a/http-add-on/values.schema.json
+++ b/http-add-on/values.schema.json
@@ -105,7 +105,7 @@
 							"description": "Tolerations for pod scheduling",
 							"type": "array",
 							"items": {
-								"type": "string"
+								"type": "object"
 							}
 						},
 						"affinity": {
@@ -175,7 +175,7 @@
 						"tolerations": {
 							"type": "array",
 							"items": {
-								"type": "string"
+								"type": "object"
 							}
 						},
 						"affinity": {
@@ -335,7 +335,7 @@
 						"tolerations": {
 							"type": "array",
 							"items": {
-								"type": "string"
+								"type": "object"
 							}
 						},
 						"affinity": {


### PR DESCRIPTION
not ok anymore:
```
helm template . --set operator.tolerations="hello" --set scaler.tolerations="json" --set interceptor.tolerations="schema"
helm template . --set operator.tolerations="hello" --set scaler.tolerations="json" --set interceptor.tolerations="schema"
Error: values don't meet the specifications of the schema(s) in the following chart(s):
keda-add-ons-http:
- interceptor.tolerations: Invalid type. Expected: array, given: string
- operator.tolerations: Invalid type. Expected: array, given: string
- scaler.tolerations: Invalid type. Expected: array, given: string
- (root): Must validate all the schemas (allOf)
```

this is ok:

```
cat <<VAL | helm template . -f -
operator:
  tolerations:
  - key: node-role.kubernetes.io/master
    effect: NoSchedule
scaler:
  tolerations:
  - key: node-role.kubernetes.io/master
    effect: NoSchedule
interceptor:
  tolerations:
  - key: node-role.kubernetes.io/master
    effect: NoSchedule
VAL
```