### PR TITLE
http-add-on: gRPC bridge between external-scaler and interceptor

### DIFF
--- a/http-add-on/templates/interceptor/deployment.yaml
+++ b/http-add-on/templates/interceptor/deployment.yaml
@@ -50,6 +50,14 @@ spec:
         imagePullPolicy: '{{ .Values.interceptor.pullPolicy | default "Always" }}'
         name: "{{ .Chart.Name }}-interceptor"
         env:
+        - name: KEDIFY_GRPC_BRIDGE_ENABLED
+          value: "{{ .Values.grpcBridge.enabled }}"
+        - name: KEDIFY_GRPC_BRIDGE_PORT
+          value: "{{ .Values.grpcBridge.port }}"
+        - name: KEDIFY_GRPC_METRIC_PUSH_PERIOD
+          value: "{{ .Values.grpcBridge.metricPushPeriod }}"
+        - name: KEDIFY_EXTERNAL_SCALER_SERVICE_NAME
+          value: "{{ .Chart.Name }}-{{ .Values.scaler.service }}"
         - name: KEDA_HTTP_CLUSTER_DOMAIN 
           value: "{{ .Values.interceptor.clusterDomain }}"
         - name: KEDA_HTTP_CURRENT_NAMESPACE

--- a/http-add-on/templates/scaler/deployment.yaml
+++ b/http-add-on/templates/scaler/deployment.yaml
@@ -53,7 +53,17 @@ spec:
         ports:
         - containerPort: {{ .Values.scaler.grpcPort }}
           name: grpc
+        {{- if .Values.grpcBridge.enabled }}
+        - containerPort: {{ .Values.grpcBridge.port }}
+          name: grpc-bridge
+        {{- end }}
+        - containerPort: {{ .Values.scaler.metrics.port }}
+          name: metrics
         env:
+        - name: KEDIFY_GRPC_BRIDGE_ENABLED
+          value: "{{ .Values.grpcBridge.enabled }}"
+        - name: KEDIFY_GRPC_BRIDGE_PORT
+          value: "{{ .Values.grpcBridge.port }}"
         - name: KEDA_HTTP_SCALER_TARGET_ADMIN_DEPLOYMENT
           value: "{{ .Chart.Name }}-interceptor"
         - name: KEDA_HTTP_SCALER_PORT

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -121,6 +121,9 @@ scaler:
       memory: 256Mi
   # -- Annotations to be added to the scaler pods
   podAnnotations: {}
+  # -- prometheus metrics endpoint
+  metrics:
+    port: 2223
 
 interceptor:
   # -- The cluster domain used for in cluster routing with envoy fleet
@@ -430,3 +433,11 @@ kubectlImage:
   repository: ghcr.io/kedify/kubectl
   pullPolicy: Always
   pullSecrets: []
+
+# -- gRPC bridge between external-scaler and interceptor
+# serves as a replacement of the legacy REST /queue endpoint
+grpcBridge:
+  enabled: false
+  port: 50051
+  # setting this too high can prolong scale from zero
+  metricPushPeriod: 1s


### PR DESCRIPTION
The original protocol between http-add-on external-scaler and interceptor is simple REST. There is an upstream issue discussing leveraging the external-scaler gRPC protocol https://github.com/kedacore/http-add-on/issues/97, but that is not suitable for the needs of communication between these two components.

Kedify http-add-on implements a different gRPC protocol called `bridge` and this PR adds configuration options to the chart.

### Configuration
To enable the bridge, set the following section for http-add-on
```yaml
grpcBridge:
  enabled: true
```

### Prometheus Metrics
The external-scaler newly exposes prometheus metrics, there are also new set of metrics for interceptor.

#### interceptor:
```sh
# Total number of times an external-scaler service was not ready
kedify_grpc_bridge_not_ready_total

# Total number of gRPC reconnects to external-scaler service
kedify_grpc_bridge_reconnect_total

# Total number of metric batches flushed to external-scaler service
kedify_grpc_bridge_metric_flush_total

# Total number of errors encountered while flushing metrics to external-scaler service
kedify_grpc_bridge_metric_flush_error_total

# Current value of metric sent to external-scaler service
kedify_grpc_bridge_scaled_object_metric_current

# Current number of gRPC sessions to external-scaler service
kedify_grpc_bridge_sessions_current
```

#### external-scaler:
```sh
# Current number of gRPC sessions established by interceptors
kedify_grpc_bridge_sessions_current

# Current value of metric sent by interceptors per ScaledObject
kedify_grpc_bridge_scaled_object_metric_current

# Total number of errors encountered while streaming metrics from interceptors
kedify_grpc_bridge_metric_stream_error_total

# Total number of metric batches received from interceptors streams
kedify_grpc_bridge_metric_stream_total
```

### Empirical Results

Following is a graph of calls made by KEDA to http-add-on external-scaler through the KEDA gRPC API. In this scenario, there are 15 applications scaled to 0, then periodically, 5 get selected to go through cold-start at the same time:
- when bridge is enabled, KEDA makes ~1.5 requests per minute to external-scaler
- when legacy `/queue` pinger is enabled, KEDA makes ~75 requests per minute to external-scaler and during simultaneous 5 application cold-start http-add-on, crashes

<img width="2133" height="815" alt="bridge_metrics" src="https://github.com/user-attachments/assets/5fc24bd9-d9ef-483a-b32e-eca630909c2d" />