### PR TITLE
allow rendering custom RBAC rules via .agent.extraRbacRules & custom k8s objects via .agent.extraObjects

### DIFF
--- a/kedify-agent/templates/extensibility/extra-cluster-role.yaml
+++ b/kedify-agent/templates/extensibility/extra-cluster-role.yaml
@@ -1,0 +1,25 @@
+{{- with .Values.agent.extraRbacRules }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kedify-agent-extra-rbac
+rules:
+{{- range . }}
+{{- tpl (toYaml .) $ -}}
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kedify-agent-can-do-extra-rbac
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kedify-agent-extra-rbac
+subjects:
+- kind: ServiceAccount
+  name: kedify-agent
+  namespace: {{ $.Release.Namespace }}
+---
+{{- end }}

--- a/kedify-agent/templates/extensibility/extra-manifests.yaml
+++ b/kedify-agent/templates/extensibility/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.agent.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/kedify-agent/values.yaml
+++ b/kedify-agent/values.yaml
@@ -165,6 +165,35 @@ agent:
     # if true, enables sync of KedifyConfiguration between cluster and the dashboard
     kedifyConfig: false
 
+  # A set of rules as documented here : https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+  # Can be used in combination with presets that create a cluster role to add additional rules.
+  # This is useful when agent should be creating also custom resources when installing kedify proxy.
+  extraRbacRules: []
+    # - apiGroups:
+    #   - 'cilium.io'
+    #   resources:
+    #   - 'ciliumnetworkpolicies'
+    #   verbs:
+    #   - '*'
+
+  # Array of extra K8s manifests to deploy together with Kedify Agent
+  extraObjects: []
+    # - apiVersion: "cilium.io/v2"
+    #   kind: CiliumNetworkPolicy
+    #   metadata:
+    #     name: "kedify-agent-netpol"
+    #   spec:
+    #     endpointSelector:
+    #       matchLabels:
+    #         control-plane: kedify-agent
+    #     egress:
+    #       - toFQDNs:
+    #         - matchName: service.kedify.io
+    #         toPorts:
+    #         - ports:
+    #           - port: "443"
+    #             protocol: TCP
+
   serviceAccount:
     # Specifies whether a service account should be created
     create: true


### PR DESCRIPTION
Useful together w/ extraObjects for `kedify-proxy` chart, because agent requires rbac for creating those.