### PR TITLE
kedify-proxy: envoy xDS keepalive

### DIFF
--- a/kedify-proxy/files/envoy-config.yaml
+++ b/kedify-proxy/files/envoy-config.yaml
@@ -37,14 +37,17 @@ dynamic_resources:
 static_resources:
   clusters:
   - name: kedify_metrics_service
-    connect_timeout: 2s
+    connect_timeout: {{ .Values.config.xds.connectTimeout }}
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     typed_extension_protocol_options:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
         "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
         explicit_http_config:
-          http2_protocol_options: {}
+          http2_protocol_options:
+            connection_keepalive:
+              interval: {{ .Values.config.xds.keepaliveInterval }}
+              timeout: {{ .Values.config.xds.keepaliveTimeout }}
     load_assignment:
       cluster_name: kedify_metrics_service
       endpoints:
@@ -55,14 +58,17 @@ static_resources:
                 address: "{{ .Values.config.kedifyEnvoyCP }}.{{ .Values.config.kedaNamespace }}.svc.{{ .Values.config.clusterDomain }}"
                 port_value: {{ .Values.config.kedifyMetricsSinkPort }}
   - name: xds_cluster
-    connect_timeout: 2s
+    connect_timeout: {{ .Values.config.xds.connectTimeout }}
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     typed_extension_protocol_options:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
         "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
         explicit_http_config:
-          http2_protocol_options: {}
+          http2_protocol_options:
+            connection_keepalive:
+              interval: {{ .Values.config.xds.keepaliveInterval }}
+              timeout: {{ .Values.config.xds.keepaliveTimeout }}
     load_assignment:
       cluster_name: xds_cluster
       endpoints:

--- a/kedify-proxy/values.yaml
+++ b/kedify-proxy/values.yaml
@@ -42,6 +42,13 @@ config:
     refreshInterval: 0.25s
     # -- max active downstream connections
     maxActiveDownstreamConnections: 10000
+  # -- gRPC xDS specific configuration
+  xds:
+    # -- keepalive settings for gRPC xDS connection to Kedify control plane
+    keepaliveInterval: 30s
+    keepaliveTimeout: 5s
+    # -- timeout for initial connection to the Kedify control plane
+    connectTimeout: 2s
 
 pod:
   # -- custom annotations that should be added to the Kedify proxy pod


### PR DESCRIPTION
configurable keepalive for kedify-proxy

see also: https://github.com/envoyproxy/go-control-plane/issues/91, https://github.com/envoyproxy/envoy/issues/21107