### PR TITLE
http-add-on: envoy xDS control-plane gRPC keepalive config

### DIFF
--- a/http-add-on/templates/interceptor/deployment.yaml
+++ b/http-add-on/templates/interceptor/deployment.yaml
@@ -58,6 +58,14 @@ spec:
           value: "{{ .Values.grpcBridge.metricPushPeriod }}"
         - name: KEDIFY_EXTERNAL_SCALER_SERVICE_NAME
           value: "{{ .Chart.Name }}-{{ .Values.scaler.service }}"
+        - name: KEDIFY_XDS_MAX_CONCURRENT_STREAMS
+          value: "{{ .Values.interceptor.xds.maxConcurrentStreams }}"
+        - name: KEDIFY_XDS_KEEPALIVE_TIME
+          value: "{{ .Values.interceptor.xds.keepalive.time }}"
+        - name: KEDIFY_XDS_KEEPALIVE_TIMEOUT
+          value: "{{ .Values.interceptor.xds.keepalive.timeout }}"
+        - name: KEDIFY_XDS_KEEPALIVE_ENFORCEMENT_POLICY_MIN_TIME
+          value: "{{ .Values.interceptor.xds.keepalive.enforcementPolicyMinTime }}"
         - name: KEDA_HTTP_CLUSTER_DOMAIN 
           value: "{{ .Values.interceptor.clusterDomain }}"
         - name: KEDA_HTTP_CURRENT_NAMESPACE

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -315,7 +315,20 @@ interceptor:
     # -- The HTTP status code to return when the application has cold-start waiting page enabled
     responseStatusCode: 503
     # -- Value in the `Retry-After` header to return when the application has cold-start waiting page enabled
-    retryAfter: 60s 
+    retryAfter: 60s
+  # -- Configuration options for the envoy xDS control-plane
+  xds:
+    # maximum number of concurrent streams that can be opened to the XDS server
+    maxConcurrentStreams: 1000000
+    # H2 keepalive settings for the gRPC connection to the XDS server
+    # https://grpc.io/docs/guides/keepalive/
+    keepalive:
+      # duration after which if the client doesn't see any activity it pings the server to see if the transport is still alive
+      time: 30s
+      # duration the client waits for a response from the server after sending a keepalive ping
+      timeout: 5s
+      # minimum amount of time a client should wait before sending a keepalive ping
+      enforcementPolicyMinTime: 30s
 
 # configuration for the images to use for each component
 images:


### PR DESCRIPTION
configurable keepalive for http-add-on envoy xDS control-plane

see also: https://github.com/envoyproxy/go-control-plane/issues/91, https://github.com/envoyproxy/envoy/issues/21107
