### PR TITLE
http-add-on: envoy xDS: wildcard default route to interceptor

### DIFF
--- a/http-add-on/templates/interceptor/deployment.yaml
+++ b/http-add-on/templates/interceptor/deployment.yaml
@@ -66,6 +66,8 @@ spec:
           value: "{{ .Values.interceptor.xds.keepalive.timeout }}"
         - name: KEDIFY_XDS_KEEPALIVE_ENFORCEMENT_POLICY_MIN_TIME
           value: "{{ .Values.interceptor.xds.keepalive.enforcementPolicyMinTime }}"
+        - name: KEDIFY_ENVOY_ENABLE_FALLBACK_CATCH_ALL_ROUTE
+          value: "{{ .Values.interceptor.fallbackCatchAllRoute.enabled }}"
         - name: KEDA_HTTP_CLUSTER_DOMAIN 
           value: "{{ .Values.interceptor.clusterDomain }}"
         - name: KEDA_HTTP_CURRENT_NAMESPACE

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -329,6 +329,11 @@ interceptor:
       timeout: 5s
       # minimum amount of time a client should wait before sending a keepalive ping
       enforcementPolicyMinTime: 30s
+  # Whether to create a fallback catch-all wildcard route in the envoy fleet that points to interceptor
+  # when enabled, this will always also enable internal metric accounting in the interceptor
+  # this is mutually exclusive with path embedded health checks because those also create wildcard route
+  fallbackCatchAllRoute:
+    enabled: false
 
 # configuration for the images to use for each component
 images:


### PR DESCRIPTION
Configuration option for envoy fleet to include wildcard default route sending everything that doesn't match any `VirtualHost` directly to interceptor. Enabling wildcard default route always enables internal metric accounting for the interceptor.

The path embedded health checks https://docs.kedify.io/scalers/http-scaler/#healthchecks-for-aws-probes use a similar heuristic with a wildcard host match. As a result, these two features are mutually exclusive.