### PR TITLE
feat: add pod security context, node selector, affinity, and tolerations to Agent init job templates

### DIFF
--- a/kedify-agent/templates/cr-install/cr-job.yaml
+++ b/kedify-agent/templates/cr-install/cr-job.yaml
@@ -26,9 +26,16 @@ spec:
       imagePullSecrets:
       {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.agent.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
+      {{- with .Values.agent.tolerations }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
       volumes:
       - name: default-kedifyconfig
         configMap:
@@ -80,4 +87,12 @@ spec:
             sleep ${_sec}
           done
           exit 1
+      {{- with .Values.agent.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.agent.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/kedify-agent/templates/crd-install/crd-job.yaml
+++ b/kedify-agent/templates/crd-install/crd-job.yaml
@@ -25,6 +25,10 @@ spec:
       imagePullSecrets:
       {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.agent.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: kubectl
         image: "{{ .Values.agent.kubectlImage.repository }}:{{ .Values.agent.kubectlImage.tag }}"
@@ -67,5 +71,17 @@ spec:
 {{- end }}
 {{- end }}
       restartPolicy: Never
+      {{- with .Values.agent.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.agent.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.agent.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
   backoffLimit: 4
 {{- end }}


### PR DESCRIPTION
If we applied some selectors or tolerations on agent, these were not propagated to the init jobs. 