### PR TITLE
Enable PRP by default

### DIFF
--- a/kedify-agent/values.yaml
+++ b/kedify-agent/values.yaml
@@ -115,7 +115,7 @@ agent:
   nameOverride: ""
   fullnameOverride: ""
   features:
-    podResourceProfilesEnabled: false
+    podResourceProfilesEnabled: true
     prpRequiresAnnotatedPods: true
   autowire:
     serviceSyncPeriod: 500ms


### PR DESCRIPTION
K8s 1.33 is more common now, there's no need to hide this behind feature flag anymore.