### PR TITLE
Add OTel addon as another sub-chart of kedify-agent

### DIFF
--- a/.github/workflows/helm-rebuild-deps.yaml
+++ b/.github/workflows/helm-rebuild-deps.yaml
@@ -1,0 +1,46 @@
+name: Helm deps
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'kedify-agent/Chart.yaml'
+permissions:
+  contents: read
+
+jobs:
+  build-helm-deps:
+    permissions:
+      contents: write  # for peter-evans/create-pull-request to create branch
+      pull-requests: write  # for peter-evans/create-pull-request to create a PR
+    name: Update Helm Deps
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      - name: Rebuild the lock file for chart dependencies
+        run: |
+          helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+          helm repo update open-telemetry
+          pushd ./kedify-agent/ && helm dependency update . && helm dependency build . && popd
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
+        id: cpr
+        with:
+          title: "Update Helm Chart.lock for kedify-agent"
+          branch: ci-helm-deps
+          delete-branch: true
+          base: main
+          signoff: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          body: |
+            :package: kedify-agent/Chart.lock update :package:
+            ### automated change
+            Running helm dependency build on updated sub-chart versions.
+            
+            This automated PR was created by [this action](https://github.com/kedify/charts/actions/runs/${{ github.run_id }}).
+      - name: Check PR
+        run: |
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}" | tee -a "$GITHUB_STEP_SUMMARY"
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}" | tee -a "$GITHUB_STEP_SUMMARY"

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -623,7 +623,7 @@ volumes:
 prometheus:
   metricServer:
     # -- Enable metric server Prometheus metrics expose
-    enabled: false
+    enabled: true
     # -- HTTP port used for exposing metrics server prometheus metrics
     port: 8080
     # -- HTTP port name for exposing metrics server prometheus metrics
@@ -680,7 +680,7 @@ prometheus:
       metricRelabelings: []
   operator:
     # -- Enable KEDA Operator prometheus metrics expose
-    enabled: false
+    enabled: true
     # -- Port used for exposing KEDA Operator prometheus metrics
     port: 8080
     # -- App Protocol for service when scraping metrics endpoint
@@ -753,7 +753,7 @@ prometheus:
         #   labels:
   webhooks:
     # -- Enable KEDA admission webhooks prometheus metrics expose
-    enabled: false
+    enabled: true
     # -- Port used for exposing KEDA admission webhooks prometheus metrics
     port: 8080
     # -- App Protocol for service when scraping metrics endpoint

--- a/kedify-agent/Chart.lock
+++ b/kedify-agent/Chart.lock
@@ -5,5 +5,8 @@ dependencies:
 - name: keda-add-ons-http
   repository: https://kedify.github.io/charts
   version: v0.11.0-0
-digest: sha256:76586c382e9d38d268dbb9df90221af6f0444ef696ed3d47ceb6c51b25797aa7
-generated: "2025-09-26T11:30:34.037878758Z"
+- name: otel-add-on
+  repository: oci://ghcr.io/kedify/charts
+  version: v0.1.2
+digest: sha256:b498abe0875b64447360e68032913b1dabc0367554c8c1b23bbc295da49f0803
+generated: "2025-10-09T13:24:10.099027+02:00"

--- a/kedify-agent/Chart.yaml
+++ b/kedify-agent/Chart.yaml
@@ -15,6 +15,10 @@ dependencies:
     repository: https://kedify.github.io/charts
     version: v0.11.0-0
     condition: kedaAddOnsHttp.enabled,keda-add-ons-http.enabled
+  - name: otel-add-on
+    repository: oci://ghcr.io/kedify/charts
+    version: v0.1.2
+    condition: otelAddOn.enabled,otel-add-on.enabled
 home: https://github.com/kedify/charts
 sources:
   - https://github.com/kedify/agent

--- a/kedify-agent/templates/NOTES.txt
+++ b/kedify-agent/templates/NOTES.txt
@@ -15,3 +15,6 @@ You have successfully installed the:
 {{- if (or (and .Values.kedaAddOnsHttp .Values.kedaAddOnsHttp.enabled) (and (index .Values "keda-add-ons-http") (index .Values "keda-add-ons-http").enabled)) }}
  - keda-add-ons-http
 {{- end}}
+{{- if (or (and .Values.otelAddOn .Values.otelAddOn.enabled) (and (index .Values "otel-add-on") (index .Values "otel-add-on").enabled)) }}
+ - keda-add-ons-otel
+{{- end}}

--- a/kedify-agent/values.yaml
+++ b/kedify-agent/values.yaml
@@ -240,3 +240,9 @@ keda-add-ons-http:
   interceptor:
     scaledObject:
       waitForCrd: true
+otel-add-on:
+  # for all available values, check: https://github.com/kedify/otel-add-on/blob/main/helmchart/otel-add-on/values.yaml
+  enabled: false
+  fullnameOverride: kedify-otel-scaler
+  otelOperator:
+    enabled: true

--- a/renovate.json5
+++ b/renovate.json5
@@ -20,6 +20,11 @@
       // paused, because the image tag is being updated by PR from a gh action on agent's repo
       "enabled": false,
     },
+    {
+      "packageNames": [
+        "ghcr.io/kedify/charts/otel-add-on", // helm chart
+      ],
+    },
   ],
   "regexManagers": [
     {
@@ -29,6 +34,15 @@
       "depNameTemplate": "ghcr.io/kedify/agent",
       "matchStrings": [
         "tag:\\s+\"?(?<currentValue>[^\"\n]+)\"?\\s*\n",
+      ],
+    },
+    {
+      // kedify OTel Addon
+      "fileMatch": ["^kedify-agent/Chart.yaml$"],
+      "datasourceTemplate": "docker", // not a typo, OCI helm charts are use 'docker' template
+      "depNameTemplate": "ghcr.io/kedify/charts/otel-add-on",
+      "matchStrings": [
+        "repository:\\s+oci://ghcr.io/kedify/charts\\s*\n\\s+version:\\s+\"?(?<currentValue>[^\"\n]+)\"?\\s*\n",
       ],
     },
   ],


### PR DESCRIPTION
so that we can install everything at once

Fix #280

worked:

```
helm upgrade -i kedify-agent . --create-namespace -nkeda \ 
 --set clusterName="my-cluster" \
 --set agent.orgId="**" \
 --set agent.apiKey="kfy_**" \
 --set keda.enabled=true \
 --set keda-add-ons-http.enabled=true\ 
 --set otel-add-on.enabled=true
Release "kedify-agent" does not exist. Installing it now.
NAME: kedify-agent
LAST DEPLOYED: Thu Oct  9 13:30:12 2025
NAMESPACE: keda
STATUS: deployed
REVISION: 1
NOTES:
>    _         _ _ ___       _
    | |_ ___ _| |_|  _|_ _  |_|___
    | '_| -_| . | |  _| | |_| | . |
    |_,_|___|___|_|_| |_  |_|_|___|
                      |___|

You have successfully installed the:
 - agent (orgId: **)
 - keda
 - keda-add-ons-http
 - keda-add-ons-otel
```