### PR TITLE
kedify-agent: rbac for EndpointSlices

### DIFF
--- a/kedify-agent/templates/rbacs/can-install-kedify-proxy.yaml
+++ b/kedify-agent/templates/rbacs/can-install-kedify-proxy.yaml
@@ -8,10 +8,24 @@ metadata:
 rules:
 # Kedify needs to configure envoy proxy also in other namespaces & deploy it
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  - endpointslices/restricted
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - ""
   resources:
   - endpoints
   - endpoints/restricted
+  - services
   verbs:
   - create
   - delete


### PR DESCRIPTION
Adding RBAC for `EndpointSlices` and `Services` so kedify-agent doesn't need to use `Endpoints` for service autowiring feature. The agent still needs `Endpoints` RBAC to delete the now-deprecated `Endpoint`.
