### PR TITLE
Add Kedify predictor as sub-chart for agent

### DIFF
--- a/kedify-agent/Chart.lock
+++ b/kedify-agent/Chart.lock
@@ -8,5 +8,8 @@ dependencies:
 - name: otel-add-on
   repository: oci://ghcr.io/kedify/charts
   version: v0.1.2
-digest: sha256:b498abe0875b64447360e68032913b1dabc0367554c8c1b23bbc295da49f0803
-generated: "2025-10-09T13:24:10.099027+02:00"
+- name: kedify-predictor
+  repository: oci://ghcr.io/kedify/charts
+  version: v0.0.1
+digest: sha256:af4d6c184835cab85b6e0b80b243179e92c85157cc7237b6680b3d3f8424bd3e
+generated: "2025-10-10T16:42:19.35379+02:00"

--- a/kedify-agent/Chart.yaml
+++ b/kedify-agent/Chart.yaml
@@ -19,6 +19,10 @@ dependencies:
     repository: oci://ghcr.io/kedify/charts
     version: v0.1.2
     condition: otelAddOn.enabled,otel-add-on.enabled
+  - name: kedify-predictor
+    repository: oci://ghcr.io/kedify/charts
+    version: v0.0.1
+    condition: kedifyPredictor.enabled,kedify-predictor.enabled
 home: https://github.com/kedify/charts
 sources:
   - https://github.com/kedify/agent

--- a/kedify-agent/templates/NOTES.txt
+++ b/kedify-agent/templates/NOTES.txt
@@ -12,9 +12,12 @@ You have successfully installed the:
 {{- if .Values.keda.enabled }}
  - keda
 {{- end}}
-{{- if (or (and .Values.kedaAddOnsHttp .Values.kedaAddOnsHttp.enabled) (and (index .Values "keda-add-ons-http") (index .Values "keda-add-ons-http").enabled)) }}
+{{- if (or ((.Values.kedaAddOnsHttp).enabled) (and (index .Values "keda-add-ons-http") (index .Values "keda-add-ons-http").enabled)) }}
  - keda-add-ons-http
 {{- end}}
-{{- if (or (and .Values.otelAddOn .Values.otelAddOn.enabled) (and (index .Values "otel-add-on") (index .Values "otel-add-on").enabled)) }}
+{{- if (or ((.Values.otelAddOn).enabled) (and (index .Values "otel-add-on") (index .Values "otel-add-on").enabled)) }}
  - keda-add-ons-otel
+{{- end}}
+{{- if (or ((.Values.kedifyPredictor).enabled) (and (index .Values "kedify-predictor") (index .Values "kedify-predictor").enabled)) }}
+ - kedify-predictor
 {{- end}}

--- a/kedify-agent/values.yaml
+++ b/kedify-agent/values.yaml
@@ -246,3 +246,9 @@ otel-add-on:
   fullnameOverride: kedify-otel-scaler
   otelOperator:
     enabled: true
+kedify-predictor:
+  # for all available values, check: https://github.com/kedify/keda-prophet/blob/main/helmchart/kedify-predictor/values.yaml
+  enabled: false
+  fullnameOverride: kedify-predictor
+  kedaPredictionController:
+    enabled: true


### PR DESCRIPTION
also simplifying those lisp-like structures in helm a bit:
`and .Values.otelAddOn .Values.otelAddOn.enabled` ~ `(.Values.otelAddOn).enabled`


looks ok:


```
helm upgrade -i kedify-agent . --create-namespace -nkeda --set clusterName="dev" \
 --set agent.agentId="**" \
 --set agent.apiKey="kfy_**" \
 --set keda.enabled=true \
 --set keda-add-ons-http.enabled=true \
 --set otel-add-on.enabled=true \
 --set kedify-predictor.enabled=true \
Release "kedify-agent" does not exist. Installing it now.
NAME: kedify-agent
LAST DEPLOYED: Fri Oct 10 17:24:04 2025
NAMESPACE: keda
STATUS: deployed
REVISION: 1
NOTES:
>    _         _ _ ___       _
    | |_ ___ _| |_|  _|_ _  |_|___
    | '_| -_| . | |  _| | |_| | . |
    |_,_|___|___|_|_| |_  |_|_|___|
                      |___|

You have successfully installed the:
 - agent (orgId: **)
 - keda
 - keda-add-ons-http
 - keda-add-ons-otel
 - kedify-predictor
```