### PR TITLE
inference port to match envoy listener for inference traffic

### DIFF
--- a/kedify-proxy/templates/envoy-deployment.yaml
+++ b/kedify-proxy/templates/envoy-deployment.yaml
@@ -106,6 +106,9 @@ spec:
             - name: admin
               containerPort: {{ .Values.service.adminPort }}
               protocol: TCP
+            - name: inference
+              containerPort: {{ .Values.service.inferencePort }}
+              protocol: TCP
           livenessProbe:
             {{- with .Values.pod.livenessProbe }}
             {{- toYaml . | nindent 12 }}

--- a/kedify-proxy/templates/services.yaml
+++ b/kedify-proxy/templates/services.yaml
@@ -24,6 +24,10 @@ spec:
       targetPort: tls
       protocol: TCP
       name: tls
+    - port: {{ .Values.service.inferencePort }}
+      targetPort: inference
+      protocol: TCP
+      name: inference
   selector:
     app: kedify-proxy
 {{- if .Values.service.exposeAdminInterface }}

--- a/kedify-proxy/values.yaml
+++ b/kedify-proxy/values.yaml
@@ -113,6 +113,8 @@ service:
   httpPort: 8080
   # -- port for TLS HTTP traffic
   tlsPort: 8443
+  # -- port for inference traffic
+  inferencePort: 9002
   # -- Should the admin service be also rendered with the helm chart?
   exposeAdminInterface: true
   # -- [docs](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types)


### PR DESCRIPTION
We previously discussed to have a separate listener on a different port to avoid disruptions on non inference traffic. This enables a separate port for the `kedify-proxy`.

This is complementary to the work on https://github.com/kedify/http-add-on/pull/198