### PR TITLE
bump kedify-proxy version on the agent

### DIFF
--- a/kedify-agent/values.yaml
+++ b/kedify-agent/values.yaml
@@ -34,7 +34,7 @@ agent:
     # otherwise it will be dynamically deployed in each namespace with HTTPScaledObject
     clusterWide: false
     chart: /helm/kedify/kedify-proxy.tgz
-    chartVersion: v0.0.7
+    chartVersion: v0.0.8
     # this will override the defaults defined in https://github.com/kedify/charts/blob/main/kedify-proxy/values.yaml
     # it configures a template for Kedify proxy which can be installed by Kedify agent either clusterwide or to each
     # namespace.


### PR DESCRIPTION
Use the new version for `kedify-proxy` chart `v0.0.8`

Relates to https://github.com/kedify/http-add-on/pull/198