### PR TITLE
http-add-on: add inferencepool rbac

### DIFF
--- a/http-add-on/templates/interceptor/rbac.yml
+++ b/http-add-on/templates/interceptor/rbac.yml
@@ -47,6 +47,14 @@ rules:
   - events
   verbs:
   - '*'
+- apiGroups:
+  - inference.networking.x-k8s.io
+  resources:
+  - inferencepools
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Add rbac for the http-add-on to watch `inferencepool` objects