### PR TITLE
migrate inferencepool rbac apigroup to inference.networking.k8s.io

### DIFF
--- a/http-add-on/templates/interceptor/rbac.yml
+++ b/http-add-on/templates/interceptor/rbac.yml
@@ -48,7 +48,7 @@ rules:
   verbs:
   - '*'
 - apiGroups:
-  - inference.networking.x-k8s.io
+  - inference.networking.k8s.io
   resources:
   - inferencepools
   verbs:


### PR DESCRIPTION
rbac to match usage of inferencepool v1 api
