### PR TITLE
http-add-on: enable gRPC bridge by default

### DIFF
--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -474,7 +474,7 @@ kubectlImage:
 # -- gRPC bridge between external-scaler and interceptor
 # serves as a replacement of the legacy REST /queue endpoint
 grpcBridge:
-  enabled: false
+  enabled: true
   port: 50051
   # setting this too high can prolong scale from zero
   metricPushPeriod: 1s


### PR DESCRIPTION
https://github.com/kedify/charts/pull/249 implemented gRPC bridge between external-scaler and interceptor as a replacement to the REST `/queue` api from upstream. It has been proven stable by users. I would like to propose making it a default communication channel.