### PR TITLE
DSJ gRPC TLS handling through kube-apiserver

### DIFF
--- a/kedify-agent/files/kedify-distributedscaledjobs.yaml
+++ b/kedify-agent/files/kedify-distributedscaledjobs.yaml
@@ -9166,9 +9166,16 @@ spec:
                       description: ID is the identification of the member cluster
                         for multicluster-controller
                       type: string
+                    lastScalingProgressTime:
+                      description: |-
+                        LastScalingProgressTime is the last time the scaling made progress
+                        This is used to determine how long the member cluster has been making slow progress for rebalancing purposes
+                      format: date-time
+                      type: string
                     lastStatusChangeTime:
-                      description: LastStatusChangeTime is the last time the status
-                        changed
+                      description: |-
+                        LastStatusChangeTime is the last time the status changed
+                        This is used to determine how long the member cluster has been unhealthy for rebalancing purposes
                       format: date-time
                       type: string
                     state:

--- a/kedify-agent/templates/agent-deployment.yaml
+++ b/kedify-agent/templates/agent-deployment.yaml
@@ -133,9 +133,6 @@ spec:
             - mountPath: /etc/mc/kubeconfigs
               name: kubeconfigs
               readOnly: true
-            - mountPath: /etc/kedaorg/certs
-              name: kedaorg-certs
-              readOnly: true
             {{- with .Values.agent.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -157,10 +154,6 @@ spec:
           secret:
             defaultMode: 420
             secretName: kedify-agent-multicluster-kubeconfigs
-        - name: kedaorg-certs
-          secret:
-            defaultMode: 420
-            secretName: kedaorg-certs
       {{- with .Values.agent.volumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/kedify-agent/templates/agent-rbac.yaml
+++ b/kedify-agent/templates/agent-rbac.yaml
@@ -26,6 +26,14 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  resourceNames:
+  - kedaorg-certs
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/kedify-agent/templates/keda-certs-secret.yaml
+++ b/kedify-agent/templates/keda-certs-secret.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: Secret
-type: Opaque
-metadata:
-  name: kedaorg-certs
-  namespace: {{ .Release.Namespace }}

--- a/kedify-agent/values.yaml
+++ b/kedify-agent/values.yaml
@@ -235,9 +235,6 @@ keda:
       enabled: true
     webhooks:
       enabled: true
-  env:
-  - name: "RAW_METRICS_GRPC_PROTOCOL"
-    value: "enabled"
 keda-add-ons-http:
   # for all available values, check: https://github.com/kedify/charts/blob/main/http-add-on/values.yaml
   enabled: false


### PR DESCRIPTION
the `kedaorg-certs` belongs to KEDA chart, adding it to kedify-agent makes helm upgrades difficult, proposing to use kube-apiserver instead.