### PR TITLE
Ability to read Kubernetes Events and Jobs for monitoring purposes

### DIFF
--- a/kedify-agent/templates/agent-rbac.yaml
+++ b/kedify-agent/templates/agent-rbac.yaml
@@ -201,6 +201,9 @@ rules:
   verbs:
   - create
   - patch
+  - get
+  - list
+  - watch
 {{- if .Values.agent.rbac.readNodes }}
 # for metrics and metered billing
 - apiGroups:
@@ -213,7 +216,6 @@ rules:
   - watch
 {{- end }}
 {{- if .Values.agent.rbac.readPods }}
-# for metrics
 - apiGroups:
   - ""
   resources:
@@ -251,6 +253,14 @@ rules:
   verbs:
   - get
   - list
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
 {{- end }}
 {{- if .Values.agent.rbac.readDeploymentsClusterwide }}
 - apiGroups:


### PR DESCRIPTION
**Jobs:**
When using ScaledJobs and getting metrics, we got this:

```
kedify-agent-866488944-dgfm7 manager 01-07 14:20:03	ERROR	controller-runtime.cache.UnhandledError	Failed to watch	{"reflector": "k8s.io/client-go@v0.34.0/tools/cache/reflector.go:290", "type": "*v1.Job", "error": "failed to list *v1.Job: jobs.batch is forbidden: User \"system:serviceaccount:keda:kedify-agent\" cannot list resource \"jobs\" in API group \"batch\" at the cluster scope"}
kedify-agent-866488944-dgfm7 manager k8s.io/apimachinery/pkg/util/runtime.logError
kedify-agent-866488944-dgfm7 manager 	k8s.io/apimachinery@v0.34.0/pkg/util/runtime/runtime.go:221
kedify-agent-866488944-dgfm7 manager k8s.io/apimachinery/pkg/util/runtime.handleError
kedify-agent-866488944-dgfm7 manager 	k8s.io/apimachinery@v0.34.0/pkg/util/runtime/runtime.go:212
kedify-agent-866488944-dgfm7 manager k8s.io/apimachinery/pkg/util/runtime.HandleErrorWithContext
kedify-agent-866488944-dgfm7 manager 	k8s.io/apimachinery@v0.34.0/pkg/util/runtime/runtime.go:198
kedify-agent-866488944-dgfm7 manager k8s.io/client-go/tools/cache.DefaultWatchErrorHandler
kedify-agent-866488944-dgfm7 manager 	k8s.io/client-go@v0.34.0/tools/cache/reflector.go:205
kedify-agent-866488944-dgfm7 manager k8s.io/client-go/tools/cache.(*Reflector).RunWithContext.func1
kedify-agent-866488944-dgfm7 manager 	k8s.io/client-go@v0.34.0/tools/cache/reflector.go:361
kedify-agent-866488944-dgfm7 manager k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1
kedify-agent-866488944-dgfm7 manager 	k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:233
kedify-agent-866488944-dgfm7 manager k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext.func1
kedify-agent-866488944-dgfm7 manager 	k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:255
kedify-agent-866488944-dgfm7 manager k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext
kedify-agent-866488944-dgfm7 manager 	k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:256
kedify-agent-866488944-dgfm7 manager k8s.io/apimachinery/pkg/util/wait.BackoffUntil
kedify-agent-866488944-dgfm7 manager 	k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:233
kedify-agent-866488944-dgfm7 manager k8s.io/client-go/tools/cache.(*Reflector).RunWithContext
kedify-agent-866488944-dgfm7 manager 	k8s.io/client-go@v0.34.0/tools/cache/reflector.go:359
kedify-agent-866488944-dgfm7 manager k8s.io/client-go/tools/cache.(*controller).RunWithContext.(*Group).StartWithContext.func3
kedify-agent-866488944-dgfm7 manager 	k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:63
kedify-agent-866488944-dgfm7 manager k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1
kedify-agent-866488944-dgfm7 manager 	k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:72
```

**Events:**
- So we can display Events in the dashboard