### PR TITLE
agent: fix extra rbac templating

### DIFF
--- a/kedify-agent/templates/extensibility/extra-cluster-role.yaml
+++ b/kedify-agent/templates/extensibility/extra-cluster-role.yaml
@@ -5,9 +5,7 @@ kind: ClusterRole
 metadata:
   name: kedify-agent-extra-rbac
 rules:
-{{- range . }}
-{{- tpl (toYaml .) $ -}}
-{{- end }}
+{{- tpl (toYaml .) $ | nindent 2 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
adding `extraRbacRules` results in buggy templating
```yaml
agent:
  extraRbacRules:
    - apiGroups: ["argoproj.io"]
      resources: ["rollouts"]
      verbs: ["get", "list", "watch"]
```
will template as
```yaml
---
# Source: kedify-agent/templates/extensibility/extra-cluster-role.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: kedify-agent-extra-rbac
rules:apiGroups:
- argoproj.io
resources:
- rollouts
verbs:
- get
- list
- watch
---
```

This PR fixes it to render as
```yaml
---
# Source: kedify-agent/templates/extensibility/extra-cluster-role.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: kedify-agent-extra-rbac
rules:
  - apiGroups:
    - argoproj.io
    resources:
    - rollouts
    verbs:
    - get
    - list
    - watch
---
```