### PR TITLE
Add observedHelmValues & helmReleaseName fields to kedifyconfig status

### DIFF
--- a/kedify-agent/files/kedify-configuration.yaml
+++ b/kedify-agent/files/kedify-configuration.yaml
@@ -316,6 +316,8 @@ spec:
                     type: string
                   kedaResourcesMetrics:
                     type: string
+                  observedHelmValues:
+                    type: string
                   phase:
                     type: string
                   reason:
@@ -356,6 +358,10 @@ spec:
                       type: object
                     firstHealthyAt:
                       format: date-time
+                      type: string
+                    helmReleaseName:
+                      type: string
+                    observedHelmValues:
                       type: string
                     version:
                       type: string

--- a/kedify-agent/templates/agent-rbac.yaml
+++ b/kedify-agent/templates/agent-rbac.yaml
@@ -152,6 +152,7 @@ rules:
 {{- end }}
 
 # kedify-agent reads API key from here and stores agent_id from fleet install initialization
+# it also needs to be able to read secrets containing the helm release info of its components
 - apiGroups:
   - ""
   resources:
@@ -160,9 +161,7 @@ rules:
   - get
   - delete
   - update
-  resourceNames:
-  - kedify-agent
-  - sh.helm.release.v1.kedify-otel.v1
+  - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/kedify-agent/templates/cr-install/cr-configmap.yaml
+++ b/kedify-agent/templates/cr-install/cr-configmap.yaml
@@ -23,6 +23,7 @@ data:
       kedaInstallations:
       - agentAutoUpdate: false
         name: keda
+        mode: Helm
         httpAddonHelm:
           enabled: true
           values: |-
@@ -32,6 +33,10 @@ data:
           values: |-
             ---
         kedaHelm:
+          enabled: true
+          values: |-
+            ---
+        predictorAddonHelm:
           enabled: true
           values: |-
             ---

--- a/kedify-agent/values.yaml
+++ b/kedify-agent/values.yaml
@@ -81,7 +81,7 @@ agent:
   # default kedify config that will be created if createKedifyConfiguration is enabled
   kedifyConfiguration:
     agentAutoUpdate: false
-    mode: Disabled
+    mode: Helm
     telemetry:
       controlPlane:
         interval: 30


### PR DESCRIPTION
It should hold the currently applied helm chart values for kedify agent as well as for its components. Also list for secrets to installation namespace is required because we can't know the helm release name and revision upfront.