### PR TITLE
kedify-agent: cleanup job KC finalizer

### DIFF
--- a/kedify-agent/templates/cleanup/cleanup-job.yaml
+++ b/kedify-agent/templates/cleanup/cleanup-job.yaml
@@ -47,7 +47,19 @@ spec:
           {{- if .Values.agent.createKedifyConfiguration }}
           # delete KedifyConfiguration CRs if the CRD exists
           if kubectl get crd kedifyconfigurations.install.kedify.io >/dev/null 2>&1; then
-            kubectl delete kedifyconfigurations --all -n {{ .Release.Namespace }} --ignore-not-found 2>&1
+            kubectl delete kedifyconfigurations --all -n {{ .Release.Namespace }} --ignore-not-found --timeout=30s 2>&1 || true
+            # strip finalizers from KC if still stuck so the API server can GC it
+            stuck=$(kubectl get kedifyconfigurations -n {{ .Release.Namespace }} -o name 2>/dev/null || true)
+            if [ -n "$stuck" ]; then
+              echo "removing finalizers from stuck KedifyConfigurations: $stuck"
+              for kc in $stuck; do
+                kubectl patch "$kc" -n {{ .Release.Namespace }} --type=merge -p '{"metadata":{"finalizers":null}}' 2>&1 || \
+                  echo "warn: patch failed for $kc (likely already gone)"
+              done
+              # success criterion is "are they actually gone?", not the patch exit codes
+              kubectl wait --for=delete kedifyconfigurations --all -n {{ .Release.Namespace }} --timeout=30s 2>&1 || \
+                echo "warn: some KedifyConfigurations remain after finalizer purge"
+            fi
           fi
           {{- end }}
           {{- if .Values.agent.createCrds }}
@@ -61,6 +73,8 @@ spec:
             distributedscaledjobs.keda.kedify.io \
             --ignore-not-found 2>&1
           {{- end }}
+          # never block helm uninstall on best-effort cleanup
+          exit 0
         resources:
           limits:
             cpu: 500m

--- a/kedify-agent/templates/cleanup/cleanup-rbac.yaml
+++ b/kedify-agent/templates/cleanup/cleanup-rbac.yaml
@@ -28,6 +28,7 @@ rules:
   - delete
   - get
   - list
+  - patch
   - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
KedifyConfiguration contains finalizer (mainly for historical reasons and `Managed` installation mode). When agent is already uninstalled, this finalizer doesn't get removed. Adding finalizer purge to the helm cleanup job.