### PR TITLE
agent: Bring your own secret Installation

### DIFF
--- a/kedify-agent/templates/NOTES.txt
+++ b/kedify-agent/templates/NOTES.txt
@@ -8,7 +8,11 @@
 {{- end }}
 
 You have successfully installed the:
+{{- if .Values.agent.orgId }}
  - agent (orgId: {{ .Values.agent.orgId }})
+{{- else }}
+ - agent (orgId: from Secret 'kedify-agent' key 'org_id')
+{{- end }}
 {{- if .Values.keda.enabled }}
  - keda
 {{- end}}

--- a/kedify-agent/templates/agent-deployment.yaml
+++ b/kedify-agent/templates/agent-deployment.yaml
@@ -45,8 +45,16 @@ spec:
             - name: KEDIFY_AGENT_ID
               value: {{ . }}
             {{- end }}
+            {{- if .Values.agent.orgId }}
             - name: KEDIFY_ORGANIZATION_ID
               value: {{ .Values.agent.orgId }}
+            {{- else }}
+            - name: KEDIFY_ORGANIZATION_ID
+              valueFrom:
+                secretKeyRef:
+                  name: kedify-agent
+                  key: org_id
+            {{- end }}
             - name: KEDIFY_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/kedify-agent/templates/api-key-secret.yaml
+++ b/kedify-agent/templates/api-key-secret.yaml
@@ -7,4 +7,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   apikey: {{ b64enc .Values.agent.apiKey }}
+  org_id: {{ b64enc .Values.agent.orgId }}
+  {{- if .Values.agent.agentId }}
+  agent_id: {{ b64enc .Values.agent.agentId }}
+  {{- end }}
 {{- end }}

--- a/kedify-agent/templates/api-key-secret.yaml
+++ b/kedify-agent/templates/api-key-secret.yaml
@@ -7,7 +7,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   apikey: {{ b64enc .Values.agent.apiKey }}
-  org_id: {{ b64enc .Values.agent.orgId }}
   {{- if .Values.agent.agentId }}
   agent_id: {{ b64enc .Values.agent.agentId }}
   {{- end }}

--- a/kedify-agent/values.schema.json
+++ b/kedify-agent/values.schema.json
@@ -35,7 +35,14 @@
         },
         "orgId": {
           "type": "string",
-          "format": "uuid"
+          "anyOf": [
+            {
+              "maxLength": 0
+            },
+            {
+              "format": "uuid"
+            }
+          ]
         },
         "agentId": {
           "type": "string",
@@ -67,13 +74,16 @@
       },
       "then": {
         "properties": {
+          "orgId": { "type": "string", "format": "uuid" },
           "apiKey": { "pattern": "^kfy_[a-z0-9]*$", "minLength": 10 }
-        }
+        },
+        "required": [
+          "apiKey",
+          "orgId"
+        ]
       },
       "required": [
-        "apiKey",
-        "createApiKeySecret",
-        "orgId"
+        "createApiKeySecret"
       ]
     }
   },

--- a/kedify-agent/values.yaml
+++ b/kedify-agent/values.yaml
@@ -7,8 +7,8 @@ agent:
   orgId: ""
   # you should already have this
   apiKey: ""
-  # if disabled, the Secret called 'kedify-agent' with api key has to be created by some other entity,
-  # otherwise agent won't start
+  # if disabled, the Secret called 'kedify-agent' has to be created by some other entity.
+  # expected key: 'apikey'. optional keys: 'org_id' (used when agent.orgId is empty), 'agent_id'.
   createApiKeySecret: true
   # if migrating to helm, set this to the value of the agentId from the previous installation
   agentId: ""

--- a/kedify-agent/values.yaml
+++ b/kedify-agent/values.yaml
@@ -8,7 +8,7 @@ agent:
   # you should already have this
   apiKey: ""
   # if disabled, the Secret called 'kedify-agent' has to be created by some other entity.
-  # expected key: 'apikey'. optional keys: 'org_id' (used when agent.orgId is empty), 'agent_id'.
+  # expected key: 'apikey'. optional keys in BYO secret mode: 'org_id' (used when agent.orgId is empty), 'agent_id'.
   createApiKeySecret: true
   # if migrating to helm, set this to the value of the agentId from the previous installation
   agentId: ""


### PR DESCRIPTION
Implemented backward-compatible secret handling for `kedify-agent` with optional org ID from secret, without introducing a new values model.

### Summary

- Preserved existing `createApiKeySecret` workflow.
- Added support for “bring your own secret” installs to supply org ID via secret key `org_id`.
- Kept API key source unchanged (`apikey` in secret `kedify-agent`).
- Added optional `agent_id` key in generated secret for consistency with existing cluster conventions.
- Relaxed schema so BYO-secret mode works with `agent.orgId: ""` when `createApiKeySecret: false`.

### Behavior changes

- `KEDIFY_ORGANIZATION_ID` now resolves as:
1. `.Values.agent.orgId` when non-empty (legacy behavior)
2. secret `kedify-agent` key `org_id` when `.Values.agent.orgId` is empty

- When `createApiKeySecret: true`, chart-generated secret now contains:
1. `apikey`
2. `agent_id` (only if `agent.agentId` is set)

### Schema updates

- `agent.orgId` accepts empty string or UUID.
- `apiKey`/`orgId` remain required only when `createApiKeySecret: true`.
- `createApiKeySecret: false` no longer forces `apiKey`/`orgId`, enabling BYO-secret rendering.

### Files changed

- [values.yaml](/home/jkarasek/go/src/github.com/kedify/charts/kedify-agent/values.yaml)
- [values.schema.json](/home/jkarasek/go/src/github.com/kedify/charts/kedify-agent/values.schema.json)
- [agent-deployment.yaml](/home/jkarasek/go/src/github.com/kedify/charts/kedify-agent/templates/agent-deployment.yaml)
- [api-key-secret.yaml](/home/jkarasek/go/src/github.com/kedify/charts/kedify-agent/templates/api-key-secret.yaml)
- [NOTES.txt](/home/jkarasek/go/src/github.com/kedify/charts/kedify-agent/templates/NOTES.txt)

### Example BYO-secret values

```yaml
agent:
  createApiKeySecret: false
  orgId: ""
```