### PR TITLE
Add gh action and initial json schemas for our CRDs

### DIFF
--- a/.github/scripts/openapi2jsonschema.py
+++ b/.github/scripts/openapi2jsonschema.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+
+# Derived from https://github.com/instrumenta/openapi2jsonschema
+import yaml
+import json
+import sys
+import os
+import urllib.request
+if 'DISABLE_SSL_CERT_VALIDATION' in os.environ:
+    import ssl
+    ssl._create_default_https_context = ssl._create_unverified_context
+
+def test_additional_properties():
+    for test in iter([{
+        "input": {"something": {"properties": {}}},
+        "expect": {'something': {'properties': {}, "additionalProperties": False}}
+    },{
+        "input": {"something": {"somethingelse": {}}},
+        "expect": {'something': {'somethingelse': {}}}
+    }]):
+        assert additional_properties(test["input"]) == test["expect"]
+
+def additional_properties(data, skip=False):
+    "This recreates the behaviour of kubectl at https://github.com/kubernetes/kubernetes/blob/225b9119d6a8f03fcbe3cc3d590c261965d928d0/pkg/kubectl/validation/schema.go#L312"
+    if isinstance(data, dict):
+        if "properties" in data and not skip:
+            if "additionalProperties" not in data:
+                data["additionalProperties"] = False
+        for _, v in data.items():
+            additional_properties(v)
+    return data
+
+def test_replace_int_or_string():
+    for test in iter([{
+        "input": {"something": {"format": "int-or-string"}},
+        "expect": {'something': {'oneOf': [{'type': 'string'}, {'type': 'integer'}]}}
+    },{
+        "input": {"something": {"format": "string"}},
+        "expect": {"something": {"format": "string"}},
+    }]):
+        assert replace_int_or_string(test["input"]) == test["expect"]
+
+def replace_int_or_string(data):
+    new = {}
+    try:
+        for k, v in iter(data.items()):
+            new_v = v
+            if isinstance(v, dict):
+                if "format" in v and v["format"] == "int-or-string":
+                    new_v = {"oneOf": [{"type": "string"}, {"type": "integer"}]}
+                else:
+                    new_v = replace_int_or_string(v)
+            elif isinstance(v, list):
+                new_v = list()
+                for x in v:
+                    new_v.append(replace_int_or_string(x))
+            else:
+                new_v = v
+            new[k] = new_v
+        return new
+    except AttributeError:
+        return data
+
+def allow_null_optional_fields(data, parent=None, grand_parent=None, key=None):
+    new = {}
+    try:
+        for k, v in iter(data.items()):
+            new_v = v
+            if isinstance(v, dict):
+                new_v = allow_null_optional_fields(v, data, parent, k)
+            elif isinstance(v, list):
+                new_v = list()
+                for x in v:
+                    new_v.append(allow_null_optional_fields(x, v, parent, k))
+            elif isinstance(v, str):
+                is_non_null_type = k == "type" and v != "null"
+                has_required_fields = grand_parent and "required" in grand_parent
+                if is_non_null_type and not has_required_fields:
+                    new_v = [v, "null"]
+            new[k] = new_v
+        return new
+    except AttributeError:
+        return data
+
+
+def append_no_duplicates(obj, key, value):
+    """
+    Given a dictionary, lookup the given key, if it doesn't exist create a new array.
+    Then check if the given value already exists in the array, if it doesn't add it.
+    """
+    if key not in obj:
+        obj[key] = []
+    if value not in obj[key]:
+        obj[key].append(value)
+
+
+def write_schema_file(schema, filename):
+    schemaJSON = ""
+
+    schema = additional_properties(schema, skip=not os.getenv("DENY_ROOT_ADDITIONAL_PROPERTIES"))
+    schema = replace_int_or_string(schema)
+    schemaJSON = json.dumps(schema, indent=2)
+
+    # Dealing with user input here..
+    filename = os.path.basename(filename)
+    f = open(filename, "w")
+    print(schemaJSON, file=f)
+    f.close()
+    print("JSON schema written to {filename}".format(filename=filename))
+
+
+def construct_value(load, node):
+    # Handle nodes that start with '='
+    # See https://github.com/yaml/pyyaml/issues/89
+    if not isinstance(node, yaml.ScalarNode):
+        raise yaml.constructor.ConstructorError(
+            "while constructing a value",
+            node.start_mark,
+            "expected a scalar, but found %s" % node.id, node.start_mark
+        )
+    yield str(node.value)
+
+
+if __name__ == "__main__":
+  if len(sys.argv) < 2:
+      print('Missing FILE parameter.\nUsage: %s [FILE]' % sys.argv[0])
+      exit(1)
+
+  for crdFile in sys.argv[1:]:
+      if crdFile.startswith("http"):
+        f = urllib.request.urlopen(crdFile)
+      else:
+        f = open(crdFile)
+      with f:
+          defs = []
+          yaml.SafeLoader.add_constructor(u'tag:yaml.org,2002:value', construct_value)
+          for y in yaml.load_all(f, Loader=yaml.SafeLoader):
+              if y is None:
+                  continue
+              if "items" in y:
+                  defs.extend(y["items"])
+              if "kind" not in y:
+                  continue
+              if y["kind"] != "CustomResourceDefinition":
+                  continue
+              else:
+                  defs.append(y)
+
+          for y in defs:
+              filename_format = os.getenv("FILENAME_FORMAT", "{kind}_{version}")
+              filename = ""
+              if "spec" in y and "versions" in y["spec"] and y["spec"]["versions"]:
+                  for version in y["spec"]["versions"]:
+                      if "schema" in version and "openAPIV3Schema" in version["schema"]:
+                          filename = filename_format.format(
+                              kind=y["spec"]["names"]["kind"],
+                              group=y["spec"]["group"].split(".")[0],
+                              fullgroup=y["spec"]["group"],
+                              version=version["name"],
+                          ).lower() + ".json"
+
+                          schema = version["schema"]["openAPIV3Schema"]
+                          write_schema_file(schema, filename)
+                      elif "validation" in y["spec"] and "openAPIV3Schema" in y["spec"]["validation"]:
+                          filename = filename_format.format(
+                              kind=y["spec"]["names"]["kind"],
+                              group=y["spec"]["group"].split(".")[0],
+                              fullgroup=y["spec"]["group"],
+                              version=version["name"],
+                          ).lower() + ".json"
+
+                          schema = y["spec"]["validation"]["openAPIV3Schema"]
+                          write_schema_file(schema, filename)
+              elif "spec" in y and "validation" in y["spec"] and "openAPIV3Schema" in y["spec"]["validation"]:
+                  filename = filename_format.format(
+                      kind=y["spec"]["names"]["kind"],
+                      group=y["spec"]["group"].split(".")[0],
+                      fullgroup=y["spec"]["group"],
+                      version=y["spec"]["version"],
+                  ).lower() + ".json"
+
+                  schema = y["spec"]["validation"]["openAPIV3Schema"]
+                  write_schema_file(schema, filename)
+
+  exit(0)

--- a/.github/scripts/requirements.txt
+++ b/.github/scripts/requirements.txt
@@ -1,0 +1,2 @@
+pyyaml
+pytest

--- a/.github/workflows/crd-schemas.yaml
+++ b/.github/workflows/crd-schemas.yaml
@@ -1,0 +1,54 @@
+name: CRD Schemas
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'kedify-agent/files/*'
+permissions:
+  contents: read
+
+jobs:
+  build-helm-doc:
+    permissions:
+      contents: write  # for peter-evans/create-pull-request to create branch
+      pull-requests: write  # for peter-evans/create-pull-request to create a PR
+    name: Update Helm Doc
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      - name: generate schemas for Kedify CRDs
+        run: |
+          python3 -m pip install -r .github/scripts/requirements.txt
+          CONVERSION_SCRIPT="${PWD}/.github/scripts/openapi2jsonschema.py"
+          pushd ./crd-schemas
+          for file in ../kedify-agent/files/* ; do
+            if [[ -f "$file" ]]; then
+              ${CONVERSION_SCRIPT} $file
+            fi
+          done
+          popd
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
+        id: cpr
+        with:
+          title: "Update CRD Schemas"
+          branch: ci-crd-schemas
+          add-paths: |
+            crd-schemas/*
+          labels: skip-ci
+          delete-branch: true
+          base: main
+          signoff: true
+          token: ${{ secrets.PAT_TOKEN }}
+          body: |
+            :package: CRD schemas update :package:
+            ### automated change
+            Running openapi2jsonschema tool on latest CRD files.
+            This automated PR was created by [this action](https://github.com/kedify/charts/actions/runs/${{ github.run_id }}).
+      - name: Check PR
+        run: |
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}" | tee -a "$GITHUB_STEP_SUMMARY"
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}" | tee -a "$GITHUB_STEP_SUMMARY"

--- a/crd-schemas/distributedscaledjob_v1alpha1.json
+++ b/crd-schemas/distributedscaledjob_v1alpha1.json
@@ -1,0 +1,9047 @@
+{
+  "description": "DistributedScaledJob is the Schema for the DistributedScaledJob API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DistributedScaledJobSpec defines the desired state of DistributedScaledJob",
+      "properties": {
+        "clusterScheduling": {
+          "default": {
+            "strategy": "weightedRoundRobin"
+          },
+          "description": "ClusterScheduling controls member-cluster selection strategy for DSJ.",
+          "properties": {
+            "failoverPolicy": {
+              "default": {
+                "gracePeriod": "1m",
+                "hardTaintDuration": "5m",
+                "softTaintDuration": "3m"
+              },
+              "description": "FailoverPolicy controls how the controller should behave when clusters fail",
+              "properties": {
+                "duplicationPolicy": {
+                  "default": "keepAll",
+                  "description": "DuplicationPolicy controls how duplicate jobs are resolved after pending-aware failover.\n- keepAll: keep all source and failover cluster jobs, results in temporarily exceeded maxReplicaCount during failover but provides better availability (default)\n- preferFailover: prefer failover cluster job over source cluster job, delete source cluster job only when failover cluster job is running, best effort avoids maxReplicaCount exceed\n- preferSource: prefer source cluster job over failover cluster job, delete failover cluster job immediately, can cause running job preemption when source cluster recovers during failover, best effort avoids maxReplicaCount exceed\n- immediateSourceCleanup: clean up source cluster job right after failover",
+                  "enum": [
+                    "immediateSourceCleanup",
+                    "keepAll",
+                    "preferFailover",
+                    "preferSource"
+                  ],
+                  "type": "string"
+                },
+                "gracePeriod": {
+                  "default": "1m",
+                  "description": "GracePeriod is the duration to wait before re-creating Jobs that fail to progress from Pending to Running state",
+                  "type": "string"
+                },
+                "hardTaintDuration": {
+                  "default": "5m",
+                  "description": "HardTaintDuration is the duration to taint a failing cluster before attempting to scale Jobs on it again",
+                  "type": "string"
+                },
+                "softTaintDuration": {
+                  "default": "3m",
+                  "description": "SoftTaintDuration is the time window to wait for a second failure before applying a hard taint.\nSet to 0s to disable soft taint and hard-taint on the first failure.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "strategy": {
+              "default": "weightedRoundRobin",
+              "description": "Strategy defines how member clusters are selected when creating Jobs.",
+              "enum": [
+                "weightedRoundRobin",
+                "priorityFailover"
+              ],
+              "type": "string"
+            },
+            "workloadAffinity": {
+              "description": "WorkloadAffinity classifies workloads for failover taint matching.\nRequired when strategy=priorityFailover.",
+              "properties": {
+                "class": {
+                  "description": "Class groups workloads for failover taint matching (e.g., for org/team).",
+                  "type": "string"
+                },
+                "size": {
+                  "description": "Size is the monotonic affinity class value.",
+                  "format": "int32",
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "size"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "clusterScheduling.workloadAffinity is required when clusterScheduling.strategy=priorityFailover",
+              "rule": "self.strategy != 'priorityFailover' || has(self.workloadAffinity)"
+            },
+            {
+              "message": "clusterScheduling.workloadAffinity must be omitted when clusterScheduling.strategy=weightedRoundRobin",
+              "rule": "self.strategy == 'priorityFailover' || !has(self.workloadAffinity)"
+            }
+          ],
+          "additionalProperties": false
+        },
+        "memberClusters": {
+          "description": "MemberClusters is the list of member clusters where the ScaledJob should trigger scaling of the target workloads\nif empty, use all available member clusters",
+          "items": {
+            "description": "DistributedScaledJobMemberCluster represents a member cluster where the ScaledJob should be applied.",
+            "properties": {
+              "name": {
+                "description": "Name is the name of the member cluster.",
+                "type": "string"
+              },
+              "podOverrides": {
+                "description": "PodOverrides are applied to Job pod template for this cluster.",
+                "properties": {
+                  "affinity": {
+                    "description": "Affinity overrides pod affinity.",
+                    "properties": {
+                      "nodeAffinity": {
+                        "description": "Describes node affinity scheduling rules for the pod.",
+                        "properties": {
+                          "preferredDuringSchedulingIgnoredDuringExecution": {
+                            "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node matches the corresponding matchExpressions; the\nnode(s) with the highest sum are the most preferred.",
+                            "items": {
+                              "description": "An empty preferred scheduling term matches all objects with implicit weight 0\n(i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                              "properties": {
+                                "preference": {
+                                  "description": "A node selector term, associated with the corresponding weight.",
+                                  "properties": {
+                                    "matchExpressions": {
+                                      "description": "A list of node selector requirements by node's labels.",
+                                      "items": {
+                                        "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                                        "properties": {
+                                          "key": {
+                                            "description": "The label key that the selector applies to.",
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "matchFields": {
+                                      "description": "A list of node selector requirements by node's fields.",
+                                      "items": {
+                                        "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                                        "properties": {
+                                          "key": {
+                                            "description": "The label key that the selector applies to.",
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "weight": {
+                                  "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                                  "format": "int32",
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "preference",
+                                "weight"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "requiredDuringSchedulingIgnoredDuringExecution": {
+                            "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to an update), the system\nmay or may not try to eventually evict the pod from its node.",
+                            "properties": {
+                              "nodeSelectorTerms": {
+                                "description": "Required. A list of node selector terms. The terms are ORed.",
+                                "items": {
+                                  "description": "A null or empty node selector term matches no objects. The requirements of\nthem are ANDed.\nThe TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                  "properties": {
+                                    "matchExpressions": {
+                                      "description": "A list of node selector requirements by node's labels.",
+                                      "items": {
+                                        "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                                        "properties": {
+                                          "key": {
+                                            "description": "The label key that the selector applies to.",
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "matchFields": {
+                                      "description": "A list of node selector requirements by node's fields.",
+                                      "items": {
+                                        "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                                        "properties": {
+                                          "key": {
+                                            "description": "The label key that the selector applies to.",
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              }
+                            },
+                            "required": [
+                              "nodeSelectorTerms"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "podAffinity": {
+                        "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                        "properties": {
+                          "preferredDuringSchedulingIgnoredDuringExecution": {
+                            "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the\nnode(s) with the highest sum are the most preferred.",
+                            "items": {
+                              "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                              "properties": {
+                                "podAffinityTerm": {
+                                  "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                  "properties": {
+                                    "labelSelector": {
+                                      "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                                      "properties": {
+                                        "matchExpressions": {
+                                          "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                          "items": {
+                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                            "properties": {
+                                              "key": {
+                                                "description": "key is the label key that the selector applies to.",
+                                                "type": "string"
+                                              },
+                                              "operator": {
+                                                "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                "type": "string"
+                                              },
+                                              "values": {
+                                                "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
+                                              }
+                                            },
+                                            "required": [
+                                              "key",
+                                              "operator"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
+                                        },
+                                        "matchLabels": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "matchLabelKeys": {
+                                      "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "mismatchLabelKeys": {
+                                      "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "namespaceSelector": {
+                                      "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                      "properties": {
+                                        "matchExpressions": {
+                                          "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                          "items": {
+                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                            "properties": {
+                                              "key": {
+                                                "description": "key is the label key that the selector applies to.",
+                                                "type": "string"
+                                              },
+                                              "operator": {
+                                                "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                "type": "string"
+                                              },
+                                              "values": {
+                                                "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
+                                              }
+                                            },
+                                            "required": [
+                                              "key",
+                                              "operator"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
+                                        },
+                                        "matchLabels": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "namespaces": {
+                                      "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "topologyKey": {
+                                      "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "topologyKey"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "weight": {
+                                  "description": "weight associated with matching the corresponding podAffinityTerm,\nin the range 1-100.",
+                                  "format": "int32",
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "podAffinityTerm",
+                                "weight"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "requiredDuringSchedulingIgnoredDuringExecution": {
+                            "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.\nWhen there are multiple elements, the lists of nodes corresponding to each\npodAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                            "items": {
+                              "description": "Defines a set of pods (namely those matching the labelSelector\nrelative to the given namespace(s)) that this pod should be\nco-located (affinity) or not co-located (anti-affinity) with,\nwhere co-located is defined as running on a node whose value of\nthe label with key <topologyKey> matches that of any node on which\na pod of the set of pods is running",
+                              "properties": {
+                                "labelSelector": {
+                                  "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                                  "properties": {
+                                    "matchExpressions": {
+                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                      "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the label key that the selector applies to.",
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "matchLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "matchLabelKeys": {
+                                  "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "mismatchLabelKeys": {
+                                  "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "namespaceSelector": {
+                                  "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                  "properties": {
+                                    "matchExpressions": {
+                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                      "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the label key that the selector applies to.",
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "matchLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "namespaces": {
+                                  "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "topologyKey": {
+                                  "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "topologyKey"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "podAntiAffinity": {
+                        "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                        "properties": {
+                          "preferredDuringSchedulingIgnoredDuringExecution": {
+                            "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe anti-affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling anti-affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and subtracting\n\"weight\" from the sum if the node has pods which matches the corresponding podAffinityTerm; the\nnode(s) with the highest sum are the most preferred.",
+                            "items": {
+                              "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                              "properties": {
+                                "podAffinityTerm": {
+                                  "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                  "properties": {
+                                    "labelSelector": {
+                                      "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                                      "properties": {
+                                        "matchExpressions": {
+                                          "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                          "items": {
+                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                            "properties": {
+                                              "key": {
+                                                "description": "key is the label key that the selector applies to.",
+                                                "type": "string"
+                                              },
+                                              "operator": {
+                                                "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                "type": "string"
+                                              },
+                                              "values": {
+                                                "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
+                                              }
+                                            },
+                                            "required": [
+                                              "key",
+                                              "operator"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
+                                        },
+                                        "matchLabels": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "matchLabelKeys": {
+                                      "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "mismatchLabelKeys": {
+                                      "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "namespaceSelector": {
+                                      "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                      "properties": {
+                                        "matchExpressions": {
+                                          "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                          "items": {
+                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                            "properties": {
+                                              "key": {
+                                                "description": "key is the label key that the selector applies to.",
+                                                "type": "string"
+                                              },
+                                              "operator": {
+                                                "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                "type": "string"
+                                              },
+                                              "values": {
+                                                "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
+                                              }
+                                            },
+                                            "required": [
+                                              "key",
+                                              "operator"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
+                                        },
+                                        "matchLabels": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "namespaces": {
+                                      "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "topologyKey": {
+                                      "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "topologyKey"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "weight": {
+                                  "description": "weight associated with matching the corresponding podAffinityTerm,\nin the range 1-100.",
+                                  "format": "int32",
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "podAffinityTerm",
+                                "weight"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "requiredDuringSchedulingIgnoredDuringExecution": {
+                            "description": "If the anti-affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the anti-affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.\nWhen there are multiple elements, the lists of nodes corresponding to each\npodAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                            "items": {
+                              "description": "Defines a set of pods (namely those matching the labelSelector\nrelative to the given namespace(s)) that this pod should be\nco-located (affinity) or not co-located (anti-affinity) with,\nwhere co-located is defined as running on a node whose value of\nthe label with key <topologyKey> matches that of any node on which\na pod of the set of pods is running",
+                              "properties": {
+                                "labelSelector": {
+                                  "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                                  "properties": {
+                                    "matchExpressions": {
+                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                      "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the label key that the selector applies to.",
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "matchLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "matchLabelKeys": {
+                                  "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "mismatchLabelKeys": {
+                                  "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "namespaceSelector": {
+                                  "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                  "properties": {
+                                    "matchExpressions": {
+                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                      "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the label key that the selector applies to.",
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "matchLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "namespaces": {
+                                  "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "topologyKey": {
+                                  "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "topologyKey"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "containerOverrides": {
+                    "additionalProperties": {
+                      "description": "DistributedScaledJobContainerOverrides defines container-level overrides for a single member cluster.",
+                      "properties": {
+                        "env": {
+                          "description": "Env overrides container environment variables.",
+                          "items": {
+                            "description": "EnvVar represents an environment variable present in a Container.",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the environment variable.\nMay consist of any printable ASCII characters except '='.",
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
+                                "type": "string"
+                              },
+                              "valueFrom": {
+                                "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                                "properties": {
+                                  "configMapKeyRef": {
+                                    "description": "Selects a key of a ConfigMap.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key to select.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "description": "Specify whether the ConfigMap or its key must be defined",
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "fieldRef": {
+                                    "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                                    "properties": {
+                                      "apiVersion": {
+                                        "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                        "type": "string"
+                                      },
+                                      "fieldPath": {
+                                        "description": "Path of the field to select in the specified API version.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "fieldPath"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "fileKeyRef": {
+                                    "description": "FileKeyRef selects a key of the env file.\nRequires the EnvFiles feature gate to be enabled.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key within the env file. An invalid key will prevent the pod from starting.\nThe keys defined within a source may consist of any printable ASCII characters except '='.\nDuring Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "default": false,
+                                        "description": "Specify whether the file or its key must be defined. If the file or key\ndoes not exist, then the env var is not published.\nIf optional is set to true and the specified key does not exist,\nthe environment variable will not be set in the Pod's containers.\n\nIf optional is set to false and the specified key does not exist,\nan error will be returned during Pod creation.",
+                                        "type": "boolean"
+                                      },
+                                      "path": {
+                                        "description": "The path within the volume from which to select the file.\nMust be relative and may not contain the '..' path or start with '..'.",
+                                        "type": "string"
+                                      },
+                                      "volumeName": {
+                                        "description": "The name of the volume mount containing the env file.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "path",
+                                      "volumeName"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "resourceFieldRef": {
+                                    "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                                    "properties": {
+                                      "containerName": {
+                                        "description": "Container name: required for volumes, optional for env vars",
+                                        "type": "string"
+                                      },
+                                      "divisor": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "resource": {
+                                        "description": "Required: resource to select",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "resource"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "secretKeyRef": {
+                                    "description": "Selects a key of a secret in the pod's namespace",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "description": "Specify whether the Secret or its key must be defined",
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "image": {
+                          "description": "Image overrides container image for this cluster.",
+                          "type": "string"
+                        },
+                        "resources": {
+                          "description": "Resources partially overrides container resource requirements.",
+                          "properties": {
+                            "claims": {
+                              "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis field depends on the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                              "items": {
+                                "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                                    "type": "string"
+                                  },
+                                  "request": {
+                                    "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-map-keys": [
+                                "name"
+                              ],
+                              "x-kubernetes-list-type": "map"
+                            },
+                            "limits": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                              "type": "object"
+                            },
+                            "requests": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "description": "ContainerOverrides are keyed by container name.",
+                    "type": "object"
+                  },
+                  "nodeSelector": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "NodeSelector overrides pod nodeSelector.",
+                    "type": "object"
+                  },
+                  "tolerations": {
+                    "description": "Tolerations are merged with base tolerations.",
+                    "items": {
+                      "description": "The pod this Toleration is attached to tolerates any taint that matches\nthe triple <key,value,effect> using the matching operator <operator>.",
+                      "properties": {
+                        "effect": {
+                          "description": "Effect indicates the taint effect to match. Empty means match all taint effects.\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                          "type": "string"
+                        },
+                        "key": {
+                          "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys.\nIf the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                          "type": "string"
+                        },
+                        "operator": {
+                          "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.",
+                          "type": "string"
+                        },
+                        "tolerationSeconds": {
+                          "description": "TolerationSeconds represents the period of time the toleration (which must be\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\nit is not set, which means tolerate the taint forever (do not evict). Zero and\nnegative values will be treated as 0 (evict immediately) by the system.",
+                          "format": "int64",
+                          "type": "integer"
+                        },
+                        "value": {
+                          "description": "Value is the taint value the toleration matches to.\nIf the operator is Exists, the value should be empty, otherwise just a regular string.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "scheduling": {
+                "description": "Scheduling contains cluster-selection attributes for this member cluster.",
+                "properties": {
+                  "priority": {
+                    "description": "Priority is used by clusterScheduling.strategy=priorityFailover.\nHigher value means stronger preference.",
+                    "format": "int32",
+                    "maximum": 1000,
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "targetNamespace": {
+                "description": "TargetNamespace is the namespace in the member cluster where the scaling should be applied.\nDefaults to the namespace of the owning distributed resource if not specified.",
+                "type": "string"
+              },
+              "weight": {
+                "default": 1,
+                "description": "Weight is the weight of the member cluster for scaling distribution.",
+                "format": "int32",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "name",
+              "weight"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "maxItems": 64,
+          "type": "array",
+          "x-kubernetes-validations": [
+            {
+              "message": "memberClusters.name must be non-empty",
+              "rule": "self.all(c, c.name != '')"
+            },
+            {
+              "message": "memberClusters.name values must be unique",
+              "rule": "self.map(c, c.name).all(n, self.map(c, c.name).filter(x, x == n).size() == 1)"
+            }
+          ]
+        },
+        "scaledJobSpec": {
+          "description": "ScaledJobSpec is the specification of the KEDA ScaledJob",
+          "properties": {
+            "failedJobsHistoryLimit": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "jobTargetRef": {
+              "description": "JobSpec describes how the job execution will look like.",
+              "properties": {
+                "activeDeadlineSeconds": {
+                  "description": "Specifies the duration in seconds relative to the startTime that the job\nmay be continuously active before the system tries to terminate it; value\nmust be positive integer. If a Job is suspended (at creation or through an\nupdate), this timer will effectively be stopped and reset when the Job is\nresumed again.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "backoffLimit": {
+                  "description": "Specifies the number of retries before marking this job failed.\nDefaults to 6, unless backoffLimitPerIndex (only Indexed Job) is specified.\nWhen backoffLimitPerIndex is specified, backoffLimit defaults to 2147483647.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "backoffLimitPerIndex": {
+                  "description": "Specifies the limit for the number of retries within an\nindex before marking this index as failed. When enabled the number of\nfailures per index is kept in the pod's\nbatch.kubernetes.io/job-index-failure-count annotation. It can only\nbe set when Job's completionMode=Indexed, and the Pod's restart\npolicy is Never. The field is immutable.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "completionMode": {
+                  "description": "completionMode specifies how Pod completions are tracked. It can be\n`NonIndexed` (default) or `Indexed`.\n\n`NonIndexed` means that the Job is considered complete when there have\nbeen .spec.completions successfully completed Pods. Each Pod completion is\nhomologous to each other.\n\n`Indexed` means that the Pods of a\nJob get an associated completion index from 0 to (.spec.completions - 1),\navailable in the annotation batch.kubernetes.io/job-completion-index.\nThe Job is considered complete when there is one successfully completed Pod\nfor each index.\nWhen value is `Indexed`, .spec.completions must be specified and\n`.spec.parallelism` must be less than or equal to 10^5.\nIn addition, The Pod name takes the form\n`$(job-name)-$(index)-$(random-string)`,\nthe Pod hostname takes the form `$(job-name)-$(index)`.\n\nMore completion modes can be added in the future.\nIf the Job controller observes a mode that it doesn't recognize, which\nis possible during upgrades due to version skew, the controller\nskips updates for the Job.",
+                  "type": "string"
+                },
+                "completions": {
+                  "description": "Specifies the desired number of successfully finished pods the\njob should be run with.  Setting to null means that the success of any\npod signals the success of all pods, and allows parallelism to have any positive\nvalue.  Setting to 1 means that parallelism is limited to 1 and the success of that\npod signals the success of the job.\nMore info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "managedBy": {
+                  "description": "ManagedBy field indicates the controller that manages a Job. The k8s Job\ncontroller reconciles jobs which don't have this field at all or the field\nvalue is the reserved string `kubernetes.io/job-controller`, but skips\nreconciling Jobs with a custom value for this field.\nThe value must be a valid domain-prefixed path (e.g. acme.io/foo) -\nall characters before the first \"/\" must be a valid subdomain as defined\nby RFC 1123. All characters trailing the first \"/\" must be valid HTTP Path\ncharacters as defined by RFC 3986. The value cannot exceed 63 characters.\nThis field is immutable.\n\nThis field is beta-level. The job controller accepts setting the field\nwhen the feature gate JobManagedBy is enabled (enabled by default).",
+                  "type": "string"
+                },
+                "manualSelector": {
+                  "description": "manualSelector controls generation of pod labels and pod selectors.\nLeave `manualSelector` unset unless you are certain what you are doing.\nWhen false or unset, the system pick labels unique to this job\nand appends those labels to the pod template.  When true,\nthe user is responsible for picking unique labels and specifying\nthe selector.  Failure to pick a unique label may cause this\nand other jobs to not function correctly.  However, You may see\n`manualSelector=true` in jobs that were created with the old `extensions/v1beta1`\nAPI.\nMore info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/#specifying-your-own-pod-selector",
+                  "type": "boolean"
+                },
+                "maxFailedIndexes": {
+                  "description": "Specifies the maximal number of failed indexes before marking the Job as\nfailed, when backoffLimitPerIndex is set. Once the number of failed\nindexes exceeds this number the entire Job is marked as Failed and its\nexecution is terminated. When left as null the job continues execution of\nall of its indexes and is marked with the `Complete` Job condition.\nIt can only be specified when backoffLimitPerIndex is set.\nIt can be null or up to completions. It is required and must be\nless than or equal to 10^4 when is completions greater than 10^5.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "parallelism": {
+                  "description": "Specifies the maximum desired number of pods the job should\nrun at any given time. The actual number of pods running in steady state will\nbe less than this number when ((.spec.completions - .status.successful) < .spec.parallelism),\ni.e. when the work left to do is less than max parallelism.\nMore info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "podFailurePolicy": {
+                  "description": "Specifies the policy of handling failed pods. In particular, it allows to\nspecify the set of actions and conditions which need to be\nsatisfied to take the associated action.\nIf empty, the default behaviour applies - the counter of failed pods,\nrepresented by the jobs's .status.failed field, is incremented and it is\nchecked against the backoffLimit. This field cannot be used in combination\nwith restartPolicy=OnFailure.",
+                  "properties": {
+                    "rules": {
+                      "description": "A list of pod failure policy rules. The rules are evaluated in order.\nOnce a rule matches a Pod failure, the remaining of the rules are ignored.\nWhen no rule matches the Pod failure, the default handling applies - the\ncounter of pod failures is incremented and it is checked against\nthe backoffLimit. At most 20 elements are allowed.",
+                      "items": {
+                        "description": "PodFailurePolicyRule describes how a pod failure is handled when the requirements are met.\nOne of onExitCodes and onPodConditions, but not both, can be used in each rule.",
+                        "properties": {
+                          "action": {
+                            "description": "Specifies the action taken on a pod failure when the requirements are satisfied.\nPossible values are:\n\n- FailJob: indicates that the pod's job is marked as Failed and all\n  running pods are terminated.\n- FailIndex: indicates that the pod's index is marked as Failed and will\n  not be restarted.\n- Ignore: indicates that the counter towards the .backoffLimit is not\n  incremented and a replacement pod is created.\n- Count: indicates that the pod is handled in the default way - the\n  counter towards the .backoffLimit is incremented.\nAdditional values are considered to be added in the future. Clients should\nreact to an unknown action by skipping the rule.",
+                            "type": "string"
+                          },
+                          "onExitCodes": {
+                            "description": "Represents the requirement on the container exit codes.",
+                            "properties": {
+                              "containerName": {
+                                "description": "Restricts the check for exit codes to the container with the\nspecified name. When null, the rule applies to all containers.\nWhen specified, it should match one the container or initContainer\nnames in the pod template.",
+                                "type": "string"
+                              },
+                              "operator": {
+                                "description": "Represents the relationship between the container exit code(s) and the\nspecified values. Containers completed with success (exit code 0) are\nexcluded from the requirement check. Possible values are:\n\n- In: the requirement is satisfied if at least one container exit code\n  (might be multiple if there are multiple containers not restricted\n  by the 'containerName' field) is in the set of specified values.\n- NotIn: the requirement is satisfied if at least one container exit code\n  (might be multiple if there are multiple containers not restricted\n  by the 'containerName' field) is not in the set of specified values.\nAdditional values are considered to be added in the future. Clients should\nreact to an unknown operator by assuming the requirement is not satisfied.",
+                                "type": "string"
+                              },
+                              "values": {
+                                "description": "Specifies the set of values. Each returned container exit code (might be\nmultiple in case of multiple containers) is checked against this set of\nvalues with respect to the operator. The list of values must be ordered\nand must not contain duplicates. Value '0' cannot be used for the In operator.\nAt least one element is required. At most 255 elements are allowed.",
+                                "items": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "set"
+                              }
+                            },
+                            "required": [
+                              "operator",
+                              "values"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "onPodConditions": {
+                            "description": "Represents the requirement on the pod conditions. The requirement is represented\nas a list of pod condition patterns. The requirement is satisfied if at\nleast one pattern matches an actual pod condition. At most 20 elements are allowed.",
+                            "items": {
+                              "description": "PodFailurePolicyOnPodConditionsPattern describes a pattern for matching\nan actual pod condition type.",
+                              "properties": {
+                                "status": {
+                                  "description": "Specifies the required Pod condition status. To match a pod condition\nit is required that the specified status equals the pod condition status.\nDefaults to True.",
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "description": "Specifies the required Pod condition type. To match a pod condition\nit is required that specified type equals the pod condition type.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "status",
+                                "type"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    }
+                  },
+                  "required": [
+                    "rules"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "podReplacementPolicy": {
+                  "description": "podReplacementPolicy specifies when to create replacement Pods.\nPossible values are:\n- TerminatingOrFailed means that we recreate pods\n  when they are terminating (has a metadata.deletionTimestamp) or failed.\n- Failed means to wait until a previously created Pod is fully terminated (has phase\n  Failed or Succeeded) before creating a replacement Pod.\n\nWhen using podFailurePolicy, Failed is the the only allowed value.\nTerminatingOrFailed and Failed are allowed values when podFailurePolicy is not in use.",
+                  "type": "string"
+                },
+                "selector": {
+                  "description": "A label query over pods that should match the pod count.\nNormally, the system sets this field for you.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors",
+                  "properties": {
+                    "matchExpressions": {
+                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                      "items": {
+                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                        "properties": {
+                          "key": {
+                            "description": "key is the label key that the selector applies to.",
+                            "type": "string"
+                          },
+                          "operator": {
+                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "operator"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    },
+                    "matchLabels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "successPolicy": {
+                  "description": "successPolicy specifies the policy when the Job can be declared as succeeded.\nIf empty, the default behavior applies - the Job is declared as succeeded\nonly when the number of succeeded pods equals to the completions.\nWhen the field is specified, it must be immutable and works only for the Indexed Jobs.\nOnce the Job meets the SuccessPolicy, the lingering pods are terminated.",
+                  "properties": {
+                    "rules": {
+                      "description": "rules represents the list of alternative rules for the declaring the Jobs\nas successful before `.status.succeeded >= .spec.completions`. Once any of the rules are met,\nthe \"SuccessCriteriaMet\" condition is added, and the lingering pods are removed.\nThe terminal state for such a Job has the \"Complete\" condition.\nAdditionally, these rules are evaluated in order; Once the Job meets one of the rules,\nother rules are ignored. At most 20 elements are allowed.",
+                      "items": {
+                        "description": "SuccessPolicyRule describes rule for declaring a Job as succeeded.\nEach rule must have at least one of the \"succeededIndexes\" or \"succeededCount\" specified.",
+                        "properties": {
+                          "succeededCount": {
+                            "description": "succeededCount specifies the minimal required size of the actual set of the succeeded indexes\nfor the Job. When succeededCount is used along with succeededIndexes, the check is\nconstrained only to the set of indexes specified by succeededIndexes.\nFor example, given that succeededIndexes is \"1-4\", succeededCount is \"3\",\nand completed indexes are \"1\", \"3\", and \"5\", the Job isn't declared as succeeded\nbecause only \"1\" and \"3\" indexes are considered in that rules.\nWhen this field is null, this doesn't default to any value and\nis never evaluated at any time.\nWhen specified it needs to be a positive integer.",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "succeededIndexes": {
+                            "description": "succeededIndexes specifies the set of indexes\nwhich need to be contained in the actual set of the succeeded indexes for the Job.\nThe list of indexes must be within 0 to \".spec.completions-1\" and\nmust not contain duplicates. At least one element is required.\nThe indexes are represented as intervals separated by commas.\nThe intervals can be a decimal integer or a pair of decimal integers separated by a hyphen.\nThe number are listed in represented by the first and last element of the series,\nseparated by a hyphen.\nFor example, if the completed indexes are 1, 3, 4, 5 and 7, they are\nrepresented as \"1,3-5,7\".\nWhen this field is null, this field doesn't default to any value\nand is never evaluated at any time.",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    }
+                  },
+                  "required": [
+                    "rules"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "suspend": {
+                  "description": "suspend specifies whether the Job controller should create Pods or not. If\na Job is created with suspend set to true, no Pods are created by the Job\ncontroller. If a Job is suspended after creation (i.e. the flag goes from\nfalse to true), the Job controller will delete all active Pods associated\nwith this Job. Users must design their workload to gracefully handle this.\nSuspending a Job will reset the StartTime field of the Job, effectively\nresetting the ActiveDeadlineSeconds timer too. Defaults to false.",
+                  "type": "boolean"
+                },
+                "template": {
+                  "description": "Describes the pod that will be created when executing a job.\nThe only allowed template.spec.restartPolicy values are \"Never\" or \"OnFailure\".\nMore info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/",
+                  "properties": {
+                    "metadata": {
+                      "description": "Standard object's metadata.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                      "type": "object"
+                    },
+                    "spec": {
+                      "description": "Specification of the desired behavior of the pod.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+                      "properties": {
+                        "activeDeadlineSeconds": {
+                          "description": "Optional duration in seconds the pod may be active on the node relative to\nStartTime before the system will actively try to mark it failed and kill associated containers.\nValue must be a positive integer.",
+                          "format": "int64",
+                          "type": "integer"
+                        },
+                        "affinity": {
+                          "description": "If specified, the pod's scheduling constraints",
+                          "properties": {
+                            "nodeAffinity": {
+                              "description": "Describes node affinity scheduling rules for the pod.",
+                              "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                  "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node matches the corresponding matchExpressions; the\nnode(s) with the highest sum are the most preferred.",
+                                  "items": {
+                                    "description": "An empty preferred scheduling term matches all objects with implicit weight 0\n(i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                                    "properties": {
+                                      "preference": {
+                                        "description": "A node selector term, associated with the corresponding weight.",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "A list of node selector requirements by node's labels.",
+                                            "items": {
+                                              "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "The label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          },
+                                          "matchFields": {
+                                            "description": "A list of node selector requirements by node's fields.",
+                                            "items": {
+                                              "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "The label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      },
+                                      "weight": {
+                                        "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "preference",
+                                      "weight"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                  "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to an update), the system\nmay or may not try to eventually evict the pod from its node.",
+                                  "properties": {
+                                    "nodeSelectorTerms": {
+                                      "description": "Required. A list of node selector terms. The terms are ORed.",
+                                      "items": {
+                                        "description": "A null or empty node selector term matches no objects. The requirements of\nthem are ANDed.\nThe TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "A list of node selector requirements by node's labels.",
+                                            "items": {
+                                              "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "The label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          },
+                                          "matchFields": {
+                                            "description": "A list of node selector requirements by node's fields.",
+                                            "items": {
+                                              "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "The label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "nodeSelectorTerms"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "podAffinity": {
+                              "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                              "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                  "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the\nnode(s) with the highest sum are the most preferred.",
+                                  "items": {
+                                    "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                    "properties": {
+                                      "podAffinityTerm": {
+                                        "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                        "properties": {
+                                          "labelSelector": {
+                                            "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "items": {
+                                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "key is the label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "matchLabelKeys": {
+                                            "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          },
+                                          "mismatchLabelKeys": {
+                                            "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          },
+                                          "namespaceSelector": {
+                                            "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "items": {
+                                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "key is the label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaces": {
+                                            "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          },
+                                          "topologyKey": {
+                                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "topologyKey"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "weight": {
+                                        "description": "weight associated with matching the corresponding podAffinityTerm,\nin the range 1-100.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "podAffinityTerm",
+                                      "weight"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                  "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.\nWhen there are multiple elements, the lists of nodes corresponding to each\npodAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                  "items": {
+                                    "description": "Defines a set of pods (namely those matching the labelSelector\nrelative to the given namespace(s)) that this pod should be\nco-located (affinity) or not co-located (anti-affinity) with,\nwhere co-located is defined as running on a node whose value of\nthe label with key <topologyKey> matches that of any node on which\na pod of the set of pods is running",
+                                    "properties": {
+                                      "labelSelector": {
+                                        "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                            "items": {
+                                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "key is the label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      },
+                                      "matchLabelKeys": {
+                                        "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "namespaceSelector": {
+                                        "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                            "items": {
+                                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "key is the label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      },
+                                      "namespaces": {
+                                        "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "topologyKey": {
+                                        "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "topologyKey"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "podAntiAffinity": {
+                              "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                              "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                  "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe anti-affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling anti-affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and subtracting\n\"weight\" from the sum if the node has pods which matches the corresponding podAffinityTerm; the\nnode(s) with the highest sum are the most preferred.",
+                                  "items": {
+                                    "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                    "properties": {
+                                      "podAffinityTerm": {
+                                        "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                        "properties": {
+                                          "labelSelector": {
+                                            "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "items": {
+                                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "key is the label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "matchLabelKeys": {
+                                            "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          },
+                                          "mismatchLabelKeys": {
+                                            "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          },
+                                          "namespaceSelector": {
+                                            "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "items": {
+                                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "key is the label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaces": {
+                                            "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          },
+                                          "topologyKey": {
+                                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "topologyKey"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "weight": {
+                                        "description": "weight associated with matching the corresponding podAffinityTerm,\nin the range 1-100.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "podAffinityTerm",
+                                      "weight"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                  "description": "If the anti-affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the anti-affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.\nWhen there are multiple elements, the lists of nodes corresponding to each\npodAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                  "items": {
+                                    "description": "Defines a set of pods (namely those matching the labelSelector\nrelative to the given namespace(s)) that this pod should be\nco-located (affinity) or not co-located (anti-affinity) with,\nwhere co-located is defined as running on a node whose value of\nthe label with key <topologyKey> matches that of any node on which\na pod of the set of pods is running",
+                                    "properties": {
+                                      "labelSelector": {
+                                        "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                            "items": {
+                                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "key is the label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      },
+                                      "matchLabelKeys": {
+                                        "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "namespaceSelector": {
+                                        "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                            "items": {
+                                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "key is the label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      },
+                                      "namespaces": {
+                                        "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "topologyKey": {
+                                        "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "topologyKey"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "automountServiceAccountToken": {
+                          "description": "AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.",
+                          "type": "boolean"
+                        },
+                        "containers": {
+                          "description": "List of containers belonging to the pod.\nContainers cannot currently be added or removed.\nThere must be at least one container in a Pod.\nCannot be updated.",
+                          "items": {
+                            "description": "A single application container that you want to run within a pod.",
+                            "properties": {
+                              "args": {
+                                "description": "Arguments to the entrypoint.\nThe container image's CMD is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "command": {
+                                "description": "Entrypoint array. Not executed within a shell.\nThe container image's ENTRYPOINT is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "env": {
+                                "description": "List of environment variables to set in the container.\nCannot be updated.",
+                                "items": {
+                                  "description": "EnvVar represents an environment variable present in a Container.",
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name of the environment variable.\nMay consist of any printable ASCII characters except '='.",
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
+                                      "type": "string"
+                                    },
+                                    "valueFrom": {
+                                      "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                                      "properties": {
+                                        "configMapKeyRef": {
+                                          "description": "Selects a key of a ConfigMap.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key to select.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "description": "Specify whether the ConfigMap or its key must be defined",
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "fieldRef": {
+                                          "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                                          "properties": {
+                                            "apiVersion": {
+                                              "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                              "type": "string"
+                                            },
+                                            "fieldPath": {
+                                              "description": "Path of the field to select in the specified API version.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "fieldPath"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "fileKeyRef": {
+                                          "description": "FileKeyRef selects a key of the env file.\nRequires the EnvFiles feature gate to be enabled.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key within the env file. An invalid key will prevent the pod from starting.\nThe keys defined within a source may consist of any printable ASCII characters except '='.\nDuring Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "default": false,
+                                              "description": "Specify whether the file or its key must be defined. If the file or key\ndoes not exist, then the env var is not published.\nIf optional is set to true and the specified key does not exist,\nthe environment variable will not be set in the Pod's containers.\n\nIf optional is set to false and the specified key does not exist,\nan error will be returned during Pod creation.",
+                                              "type": "boolean"
+                                            },
+                                            "path": {
+                                              "description": "The path within the volume from which to select the file.\nMust be relative and may not contain the '..' path or start with '..'.",
+                                              "type": "string"
+                                            },
+                                            "volumeName": {
+                                              "description": "The name of the volume mount containing the env file.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "path",
+                                            "volumeName"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "resourceFieldRef": {
+                                          "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                                          "properties": {
+                                            "containerName": {
+                                              "description": "Container name: required for volumes, optional for env vars",
+                                              "type": "string"
+                                            },
+                                            "divisor": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "resource": {
+                                              "description": "Required: resource to select",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "resource"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "secretKeyRef": {
+                                          "description": "Selects a key of a secret in the pod's namespace",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "description": "Specify whether the Secret or its key must be defined",
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": [
+                                    "name"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-map-keys": [
+                                  "name"
+                                ],
+                                "x-kubernetes-list-type": "map"
+                              },
+                              "envFrom": {
+                                "description": "List of sources to populate environment variables in the container.\nThe keys defined within a source may consist of any printable ASCII characters except '='.\nWhen a key exists in multiple\nsources, the value associated with the last source will take precedence.\nValues defined by an Env with a duplicate key will take precedence.\nCannot be updated.",
+                                "items": {
+                                  "description": "EnvFromSource represents the source of a set of ConfigMaps or Secrets",
+                                  "properties": {
+                                    "configMapRef": {
+                                      "description": "The ConfigMap to select from",
+                                      "properties": {
+                                        "name": {
+                                          "default": "",
+                                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "description": "Specify whether the ConfigMap must be defined",
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "prefix": {
+                                      "description": "Optional text to prepend to the name of each environment variable.\nMay consist of any printable ASCII characters except '='.",
+                                      "type": "string"
+                                    },
+                                    "secretRef": {
+                                      "description": "The Secret to select from",
+                                      "properties": {
+                                        "name": {
+                                          "default": "",
+                                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "description": "Specify whether the Secret must be defined",
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "image": {
+                                "description": "Container image name.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.",
+                                "type": "string"
+                              },
+                              "imagePullPolicy": {
+                                "description": "Image pull policy.\nOne of Always, Never, IfNotPresent.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+                                "type": "string"
+                              },
+                              "lifecycle": {
+                                "description": "Actions that the management system should take in response to container lifecycle events.\nCannot be updated.",
+                                "properties": {
+                                  "postStart": {
+                                    "description": "PostStart is called immediately after a container is created. If the handler fails,\nthe container is terminated and restarted according to its restart policy.\nOther management of the container blocks until the hook completes.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                                    "properties": {
+                                      "exec": {
+                                        "description": "Exec specifies a command to execute in the container.",
+                                        "properties": {
+                                          "command": {
+                                            "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "description": "HTTPGet specifies an HTTP GET request to perform.",
+                                        "properties": {
+                                          "host": {
+                                            "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                            "items": {
+                                              "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                              "properties": {
+                                                "name": {
+                                                  "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "description": "The header field value",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "name",
+                                                "value"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          },
+                                          "path": {
+                                            "description": "Path to access on the HTTP server.",
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "port"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "sleep": {
+                                        "description": "Sleep represents a duration that the container should sleep.",
+                                        "properties": {
+                                          "seconds": {
+                                            "description": "Seconds is the number of seconds to sleep.",
+                                            "format": "int64",
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "required": [
+                                          "seconds"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "tcpSocket": {
+                                        "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
+                                        "properties": {
+                                          "host": {
+                                            "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "required": [
+                                          "port"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "preStop": {
+                                    "description": "PreStop is called immediately before a container is terminated due to an\nAPI request or management event such as liveness/startup probe failure,\npreemption, resource contention, etc. The handler is not called if the\ncontainer crashes or exits. The Pod's termination grace period countdown begins before the\nPreStop hook is executed. Regardless of the outcome of the handler, the\ncontainer will eventually terminate within the Pod's termination grace\nperiod (unless delayed by finalizers). Other management of the container blocks until the hook completes\nor until the termination grace period is reached.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                                    "properties": {
+                                      "exec": {
+                                        "description": "Exec specifies a command to execute in the container.",
+                                        "properties": {
+                                          "command": {
+                                            "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "description": "HTTPGet specifies an HTTP GET request to perform.",
+                                        "properties": {
+                                          "host": {
+                                            "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                            "items": {
+                                              "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                              "properties": {
+                                                "name": {
+                                                  "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "description": "The header field value",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "name",
+                                                "value"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          },
+                                          "path": {
+                                            "description": "Path to access on the HTTP server.",
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "port"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "sleep": {
+                                        "description": "Sleep represents a duration that the container should sleep.",
+                                        "properties": {
+                                          "seconds": {
+                                            "description": "Seconds is the number of seconds to sleep.",
+                                            "format": "int64",
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "required": [
+                                          "seconds"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "tcpSocket": {
+                                        "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
+                                        "properties": {
+                                          "host": {
+                                            "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "required": [
+                                          "port"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "stopSignal": {
+                                    "description": "StopSignal defines which signal will be sent to a container when it is being stopped.\nIf not specified, the default is defined by the container runtime in use.\nStopSignal can only be set for Pods with a non-empty .spec.os.name",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "livenessProbe": {
+                                "description": "Periodic probe of container liveness.\nContainer will be restarted if the probe fails.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                "properties": {
+                                  "exec": {
+                                    "description": "Exec specifies a command to execute in the container.",
+                                    "properties": {
+                                      "command": {
+                                        "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "failureThreshold": {
+                                    "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                                    "properties": {
+                                      "port": {
+                                        "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "default": "",
+                                        "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "description": "HTTPGet specifies an HTTP GET request to perform.",
+                                    "properties": {
+                                      "host": {
+                                        "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                        "items": {
+                                          "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                          "properties": {
+                                            "name": {
+                                              "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "The header field value",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "path": {
+                                        "description": "Path to access on the HTTP server.",
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "initialDelaySeconds": {
+                                    "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "description": "TCPSocket specifies a connection to a TCP port.",
+                                    "properties": {
+                                      "host": {
+                                        "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                                    "format": "int64",
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "name": {
+                                "description": "Name of the container specified as a DNS_LABEL.\nEach container in a pod must have a unique name (DNS_LABEL).\nCannot be updated.",
+                                "type": "string"
+                              },
+                              "ports": {
+                                "description": "List of ports to expose from the container. Not specifying a port here\nDOES NOT prevent that port from being exposed. Any port which is\nlistening on the default \"0.0.0.0\" address inside a container will be\naccessible from the network.\nModifying this array with strategic merge patch may corrupt the data.\nFor more information See https://github.com/kubernetes/kubernetes/issues/108255.\nCannot be updated.",
+                                "items": {
+                                  "description": "ContainerPort represents a network port in a single container.",
+                                  "properties": {
+                                    "containerPort": {
+                                      "description": "Number of port to expose on the pod's IP address.\nThis must be a valid port number, 0 < x < 65536.",
+                                      "format": "int32",
+                                      "type": "integer"
+                                    },
+                                    "hostIP": {
+                                      "description": "What host IP to bind the external port to.",
+                                      "type": "string"
+                                    },
+                                    "hostPort": {
+                                      "description": "Number of port to expose on the host.\nIf specified, this must be a valid port number, 0 < x < 65536.\nIf HostNetwork is specified, this must match ContainerPort.\nMost containers do not need this.",
+                                      "format": "int32",
+                                      "type": "integer"
+                                    },
+                                    "name": {
+                                      "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each\nnamed port in a pod must have a unique name. Name for the port that can be\nreferred to by services.",
+                                      "type": "string"
+                                    },
+                                    "protocol": {
+                                      "default": "TCP",
+                                      "description": "Protocol for port. Must be UDP, TCP, or SCTP.\nDefaults to \"TCP\".",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "containerPort"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-map-keys": [
+                                  "containerPort",
+                                  "protocol"
+                                ],
+                                "x-kubernetes-list-type": "map"
+                              },
+                              "readinessProbe": {
+                                "description": "Periodic probe of container service readiness.\nContainer will be removed from service endpoints if the probe fails.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                "properties": {
+                                  "exec": {
+                                    "description": "Exec specifies a command to execute in the container.",
+                                    "properties": {
+                                      "command": {
+                                        "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "failureThreshold": {
+                                    "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                                    "properties": {
+                                      "port": {
+                                        "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "default": "",
+                                        "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "description": "HTTPGet specifies an HTTP GET request to perform.",
+                                    "properties": {
+                                      "host": {
+                                        "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                        "items": {
+                                          "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                          "properties": {
+                                            "name": {
+                                              "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "The header field value",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "path": {
+                                        "description": "Path to access on the HTTP server.",
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "initialDelaySeconds": {
+                                    "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "description": "TCPSocket specifies a connection to a TCP port.",
+                                    "properties": {
+                                      "host": {
+                                        "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                                    "format": "int64",
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "resizePolicy": {
+                                "description": "Resources resize policy for the container.",
+                                "items": {
+                                  "description": "ContainerResizePolicy represents resource resize policy for the container.",
+                                  "properties": {
+                                    "resourceName": {
+                                      "description": "Name of the resource to which this resource resize policy applies.\nSupported values: cpu, memory.",
+                                      "type": "string"
+                                    },
+                                    "restartPolicy": {
+                                      "description": "Restart policy to apply when specified resource is resized.\nIf not specified, it defaults to NotRequired.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "resourceName",
+                                    "restartPolicy"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "resources": {
+                                "description": "Compute Resources required by this container.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                "properties": {
+                                  "claims": {
+                                    "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis field depends on the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                                    "items": {
+                                      "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                                      "properties": {
+                                        "name": {
+                                          "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                                          "type": "string"
+                                        },
+                                        "request": {
+                                          "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-map-keys": [
+                                      "name"
+                                    ],
+                                    "x-kubernetes-list-type": "map"
+                                  },
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "restartPolicy": {
+                                "description": "RestartPolicy defines the restart behavior of individual containers in a pod.\nThis overrides the pod-level restart policy. When this field is not specified,\nthe restart behavior is defined by the Pod's restart policy and the container type.\nAdditionally, setting the RestartPolicy as \"Always\" for the init container will\nhave the following effect:\nthis init container will be continually restarted on\nexit until all regular containers have terminated. Once all regular\ncontainers have completed, all init containers with restartPolicy \"Always\"\nwill be shut down. This lifecycle differs from normal init containers and\nis often referred to as a \"sidecar\" container. Although this init\ncontainer still starts in the init container sequence, it does not wait\nfor the container to complete before proceeding to the next init\ncontainer. Instead, the next init container starts immediately after this\ninit container is started, or after any startupProbe has successfully\ncompleted.",
+                                "type": "string"
+                              },
+                              "restartPolicyRules": {
+                                "description": "Represents a list of rules to be checked to determine if the\ncontainer should be restarted on exit. The rules are evaluated in\norder. Once a rule matches a container exit condition, the remaining\nrules are ignored. If no rule matches the container exit condition,\nthe Container-level restart policy determines the whether the container\nis restarted or not. Constraints on the rules:\n- At most 20 rules are allowed.\n- Rules can have the same action.\n- Identical rules are not forbidden in validations.\nWhen rules are specified, container MUST set RestartPolicy explicitly\neven it if matches the Pod's RestartPolicy.",
+                                "items": {
+                                  "description": "ContainerRestartRule describes how a container exit is handled.",
+                                  "properties": {
+                                    "action": {
+                                      "description": "Specifies the action taken on a container exit if the requirements\nare satisfied. The only possible value is \"Restart\" to restart the\ncontainer.",
+                                      "type": "string"
+                                    },
+                                    "exitCodes": {
+                                      "description": "Represents the exit codes to check on container exits.",
+                                      "properties": {
+                                        "operator": {
+                                          "description": "Represents the relationship between the container exit code(s) and the\nspecified values. Possible values are:\n- In: the requirement is satisfied if the container exit code is in the\n  set of specified values.\n- NotIn: the requirement is satisfied if the container exit code is\n  not in the set of specified values.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "Specifies the set of values to check for container exit codes.\nAt most 255 elements are allowed.",
+                                          "items": {
+                                            "format": "int32",
+                                            "type": "integer"
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "set"
+                                        }
+                                      },
+                                      "required": [
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": [
+                                    "action"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "securityContext": {
+                                "description": "SecurityContext defines the security options the container should be run with.\nIf set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.\nMore info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
+                                "properties": {
+                                  "allowPrivilegeEscalation": {
+                                    "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "type": "boolean"
+                                  },
+                                  "appArmorProfile": {
+                                    "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "type"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "capabilities": {
+                                    "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "properties": {
+                                      "add": {
+                                        "description": "Added capabilities",
+                                        "items": {
+                                          "description": "Capability represent POSIX capabilities type",
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "drop": {
+                                        "description": "Removed capabilities",
+                                        "items": {
+                                          "description": "Capability represent POSIX capabilities type",
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "privileged": {
+                                    "description": "Run container in privileged mode.\nProcesses in privileged containers are essentially equivalent to root on the host.\nDefaults to false.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "type": "boolean"
+                                  },
+                                  "procMount": {
+                                    "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "type": "string"
+                                  },
+                                  "readOnlyRootFilesystem": {
+                                    "description": "Whether this container has a read-only root filesystem.\nDefault is false.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "type": "boolean"
+                                  },
+                                  "runAsGroup": {
+                                    "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "format": "int64",
+                                    "type": "integer"
+                                  },
+                                  "runAsNonRoot": {
+                                    "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                    "type": "boolean"
+                                  },
+                                  "runAsUser": {
+                                    "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "format": "int64",
+                                    "type": "integer"
+                                  },
+                                  "seLinuxOptions": {
+                                    "description": "The SELinux context to be applied to the container.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "properties": {
+                                      "level": {
+                                        "description": "Level is SELinux level label that applies to the container.",
+                                        "type": "string"
+                                      },
+                                      "role": {
+                                        "description": "Role is a SELinux role label that applies to the container.",
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "description": "Type is a SELinux type label that applies to the container.",
+                                        "type": "string"
+                                      },
+                                      "user": {
+                                        "description": "User is a SELinux user label that applies to the container.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "seccompProfile": {
+                                    "description": "The seccomp options to use by this container. If seccomp options are\nprovided at both the pod & container level, the container options\noverride the pod options.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "type"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "windowsOptions": {
+                                    "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options from the PodSecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
+                                    "properties": {
+                                      "gmsaCredentialSpec": {
+                                        "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
+                                        "type": "string"
+                                      },
+                                      "gmsaCredentialSpecName": {
+                                        "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                                        "type": "string"
+                                      },
+                                      "hostProcess": {
+                                        "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                                        "type": "boolean"
+                                      },
+                                      "runAsUserName": {
+                                        "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "startupProbe": {
+                                "description": "StartupProbe indicates that the Pod has successfully initialized.\nIf specified, no other probes are executed until this completes successfully.\nIf this probe fails, the Pod will be restarted, just as if the livenessProbe failed.\nThis can be used to provide different probe parameters at the beginning of a Pod's lifecycle,\nwhen it might take a long time to load data or warm a cache, than during steady-state operation.\nThis cannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                "properties": {
+                                  "exec": {
+                                    "description": "Exec specifies a command to execute in the container.",
+                                    "properties": {
+                                      "command": {
+                                        "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "failureThreshold": {
+                                    "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                                    "properties": {
+                                      "port": {
+                                        "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "default": "",
+                                        "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "description": "HTTPGet specifies an HTTP GET request to perform.",
+                                    "properties": {
+                                      "host": {
+                                        "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                        "items": {
+                                          "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                          "properties": {
+                                            "name": {
+                                              "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "The header field value",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "path": {
+                                        "description": "Path to access on the HTTP server.",
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "initialDelaySeconds": {
+                                    "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "description": "TCPSocket specifies a connection to a TCP port.",
+                                    "properties": {
+                                      "host": {
+                                        "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                                    "format": "int64",
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "stdin": {
+                                "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this\nis not set, reads from stdin in the container will always result in EOF.\nDefault is false.",
+                                "type": "boolean"
+                              },
+                              "stdinOnce": {
+                                "description": "Whether the container runtime should close the stdin channel after it has been opened by\na single attach. When stdin is true the stdin stream will remain open across multiple attach\nsessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the\nfirst client attaches to stdin, and then remains open and accepts data until the client disconnects,\nat which time stdin is closed and remains closed until the container is restarted. If this\nflag is false, a container processes that reads from stdin will never receive an EOF.\nDefault is false",
+                                "type": "boolean"
+                              },
+                              "terminationMessagePath": {
+                                "description": "Optional: Path at which the file to which the container's termination message\nwill be written is mounted into the container's filesystem.\nMessage written is intended to be brief final status, such as an assertion failure message.\nWill be truncated by the node if greater than 4096 bytes. The total message length across\nall containers will be limited to 12kb.\nDefaults to /dev/termination-log.\nCannot be updated.",
+                                "type": "string"
+                              },
+                              "terminationMessagePolicy": {
+                                "description": "Indicate how the termination message should be populated. File will use the contents of\nterminationMessagePath to populate the container status message on both success and failure.\nFallbackToLogsOnError will use the last chunk of container log output if the termination\nmessage file is empty and the container exited with an error.\nThe log output is limited to 2048 bytes or 80 lines, whichever is smaller.\nDefaults to File.\nCannot be updated.",
+                                "type": "string"
+                              },
+                              "tty": {
+                                "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.\nDefault is false.",
+                                "type": "boolean"
+                              },
+                              "volumeDevices": {
+                                "description": "volumeDevices is the list of block devices to be used by the container.",
+                                "items": {
+                                  "description": "volumeDevice describes a mapping of a raw block device within a container.",
+                                  "properties": {
+                                    "devicePath": {
+                                      "description": "devicePath is the path inside of the container that the device will be mapped to.",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "name must match the name of a persistentVolumeClaim in the pod",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "devicePath",
+                                    "name"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-map-keys": [
+                                  "devicePath"
+                                ],
+                                "x-kubernetes-list-type": "map"
+                              },
+                              "volumeMounts": {
+                                "description": "Pod volumes to mount into the container's filesystem.\nCannot be updated.",
+                                "items": {
+                                  "description": "VolumeMount describes a mounting of a Volume within a container.",
+                                  "properties": {
+                                    "mountPath": {
+                                      "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
+                                      "type": "string"
+                                    },
+                                    "mountPropagation": {
+                                      "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "This must match the Name of a Volume.",
+                                      "type": "string"
+                                    },
+                                    "readOnly": {
+                                      "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
+                                      "type": "boolean"
+                                    },
+                                    "recursiveReadOnly": {
+                                      "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                                      "type": "string"
+                                    },
+                                    "subPath": {
+                                      "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
+                                      "type": "string"
+                                    },
+                                    "subPathExpr": {
+                                      "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "mountPath",
+                                    "name"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-map-keys": [
+                                  "mountPath"
+                                ],
+                                "x-kubernetes-list-type": "map"
+                              },
+                              "workingDir": {
+                                "description": "Container's working directory.\nIf not specified, the container runtime's default will be used, which\nmight be configured in the container image.\nCannot be updated.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-map-keys": [
+                            "name"
+                          ],
+                          "x-kubernetes-list-type": "map"
+                        },
+                        "dnsConfig": {
+                          "description": "Specifies the DNS parameters of a pod.\nParameters specified here will be merged to the generated DNS\nconfiguration based on DNSPolicy.",
+                          "properties": {
+                            "nameservers": {
+                              "description": "A list of DNS name server IP addresses.\nThis will be appended to the base nameservers generated from DNSPolicy.\nDuplicated nameservers will be removed.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "options": {
+                              "description": "A list of DNS resolver options.\nThis will be merged with the base options generated from DNSPolicy.\nDuplicated entries will be removed. Resolution options given in Options\nwill override those that appear in the base DNSPolicy.",
+                              "items": {
+                                "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name is this DNS resolver option's name.\nRequired.",
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Value is this DNS resolver option's value.",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "searches": {
+                              "description": "A list of DNS search domains for host-name lookup.\nThis will be appended to the base search paths generated from DNSPolicy.\nDuplicated search paths will be removed.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "dnsPolicy": {
+                          "description": "Set DNS policy for the pod.\nDefaults to \"ClusterFirst\".\nValid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'.\nDNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy.\nTo have DNS options set along with hostNetwork, you have to specify DNS policy\nexplicitly to 'ClusterFirstWithHostNet'.",
+                          "type": "string"
+                        },
+                        "enableServiceLinks": {
+                          "description": "EnableServiceLinks indicates whether information about services should be injected into pod's\nenvironment variables, matching the syntax of Docker links.\nOptional: Defaults to true.",
+                          "type": "boolean"
+                        },
+                        "ephemeralContainers": {
+                          "description": "List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing\npod to perform user-initiated actions such as debugging. This list cannot be specified when\ncreating a pod, and it cannot be modified by updating the pod spec. In order to add an\nephemeral container to an existing pod, use the pod's ephemeralcontainers subresource.",
+                          "items": {
+                            "description": "An EphemeralContainer is a temporary container that you may add to an existing Pod for\nuser-initiated activities such as debugging. Ephemeral containers have no resource or\nscheduling guarantees, and they will not be restarted when they exit or when a Pod is\nremoved or restarted. The kubelet may evict a Pod if an ephemeral container causes the\nPod to exceed its resource allocation.\n\nTo add an ephemeral container, use the ephemeralcontainers subresource of an existing\nPod. Ephemeral containers may not be removed or restarted.",
+                            "properties": {
+                              "args": {
+                                "description": "Arguments to the entrypoint.\nThe image's CMD is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "command": {
+                                "description": "Entrypoint array. Not executed within a shell.\nThe image's ENTRYPOINT is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "env": {
+                                "description": "List of environment variables to set in the container.\nCannot be updated.",
+                                "items": {
+                                  "description": "EnvVar represents an environment variable present in a Container.",
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name of the environment variable.\nMay consist of any printable ASCII characters except '='.",
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
+                                      "type": "string"
+                                    },
+                                    "valueFrom": {
+                                      "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                                      "properties": {
+                                        "configMapKeyRef": {
+                                          "description": "Selects a key of a ConfigMap.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key to select.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "description": "Specify whether the ConfigMap or its key must be defined",
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "fieldRef": {
+                                          "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                                          "properties": {
+                                            "apiVersion": {
+                                              "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                              "type": "string"
+                                            },
+                                            "fieldPath": {
+                                              "description": "Path of the field to select in the specified API version.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "fieldPath"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "fileKeyRef": {
+                                          "description": "FileKeyRef selects a key of the env file.\nRequires the EnvFiles feature gate to be enabled.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key within the env file. An invalid key will prevent the pod from starting.\nThe keys defined within a source may consist of any printable ASCII characters except '='.\nDuring Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "default": false,
+                                              "description": "Specify whether the file or its key must be defined. If the file or key\ndoes not exist, then the env var is not published.\nIf optional is set to true and the specified key does not exist,\nthe environment variable will not be set in the Pod's containers.\n\nIf optional is set to false and the specified key does not exist,\nan error will be returned during Pod creation.",
+                                              "type": "boolean"
+                                            },
+                                            "path": {
+                                              "description": "The path within the volume from which to select the file.\nMust be relative and may not contain the '..' path or start with '..'.",
+                                              "type": "string"
+                                            },
+                                            "volumeName": {
+                                              "description": "The name of the volume mount containing the env file.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "path",
+                                            "volumeName"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "resourceFieldRef": {
+                                          "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                                          "properties": {
+                                            "containerName": {
+                                              "description": "Container name: required for volumes, optional for env vars",
+                                              "type": "string"
+                                            },
+                                            "divisor": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "resource": {
+                                              "description": "Required: resource to select",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "resource"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "secretKeyRef": {
+                                          "description": "Selects a key of a secret in the pod's namespace",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "description": "Specify whether the Secret or its key must be defined",
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": [
+                                    "name"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-map-keys": [
+                                  "name"
+                                ],
+                                "x-kubernetes-list-type": "map"
+                              },
+                              "envFrom": {
+                                "description": "List of sources to populate environment variables in the container.\nThe keys defined within a source may consist of any printable ASCII characters except '='.\nWhen a key exists in multiple\nsources, the value associated with the last source will take precedence.\nValues defined by an Env with a duplicate key will take precedence.\nCannot be updated.",
+                                "items": {
+                                  "description": "EnvFromSource represents the source of a set of ConfigMaps or Secrets",
+                                  "properties": {
+                                    "configMapRef": {
+                                      "description": "The ConfigMap to select from",
+                                      "properties": {
+                                        "name": {
+                                          "default": "",
+                                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "description": "Specify whether the ConfigMap must be defined",
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "prefix": {
+                                      "description": "Optional text to prepend to the name of each environment variable.\nMay consist of any printable ASCII characters except '='.",
+                                      "type": "string"
+                                    },
+                                    "secretRef": {
+                                      "description": "The Secret to select from",
+                                      "properties": {
+                                        "name": {
+                                          "default": "",
+                                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "description": "Specify whether the Secret must be defined",
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "image": {
+                                "description": "Container image name.\nMore info: https://kubernetes.io/docs/concepts/containers/images",
+                                "type": "string"
+                              },
+                              "imagePullPolicy": {
+                                "description": "Image pull policy.\nOne of Always, Never, IfNotPresent.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+                                "type": "string"
+                              },
+                              "lifecycle": {
+                                "description": "Lifecycle is not allowed for ephemeral containers.",
+                                "properties": {
+                                  "postStart": {
+                                    "description": "PostStart is called immediately after a container is created. If the handler fails,\nthe container is terminated and restarted according to its restart policy.\nOther management of the container blocks until the hook completes.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                                    "properties": {
+                                      "exec": {
+                                        "description": "Exec specifies a command to execute in the container.",
+                                        "properties": {
+                                          "command": {
+                                            "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "description": "HTTPGet specifies an HTTP GET request to perform.",
+                                        "properties": {
+                                          "host": {
+                                            "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                            "items": {
+                                              "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                              "properties": {
+                                                "name": {
+                                                  "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "description": "The header field value",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "name",
+                                                "value"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          },
+                                          "path": {
+                                            "description": "Path to access on the HTTP server.",
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "port"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "sleep": {
+                                        "description": "Sleep represents a duration that the container should sleep.",
+                                        "properties": {
+                                          "seconds": {
+                                            "description": "Seconds is the number of seconds to sleep.",
+                                            "format": "int64",
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "required": [
+                                          "seconds"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "tcpSocket": {
+                                        "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
+                                        "properties": {
+                                          "host": {
+                                            "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "required": [
+                                          "port"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "preStop": {
+                                    "description": "PreStop is called immediately before a container is terminated due to an\nAPI request or management event such as liveness/startup probe failure,\npreemption, resource contention, etc. The handler is not called if the\ncontainer crashes or exits. The Pod's termination grace period countdown begins before the\nPreStop hook is executed. Regardless of the outcome of the handler, the\ncontainer will eventually terminate within the Pod's termination grace\nperiod (unless delayed by finalizers). Other management of the container blocks until the hook completes\nor until the termination grace period is reached.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                                    "properties": {
+                                      "exec": {
+                                        "description": "Exec specifies a command to execute in the container.",
+                                        "properties": {
+                                          "command": {
+                                            "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "description": "HTTPGet specifies an HTTP GET request to perform.",
+                                        "properties": {
+                                          "host": {
+                                            "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                            "items": {
+                                              "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                              "properties": {
+                                                "name": {
+                                                  "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "description": "The header field value",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "name",
+                                                "value"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          },
+                                          "path": {
+                                            "description": "Path to access on the HTTP server.",
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "port"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "sleep": {
+                                        "description": "Sleep represents a duration that the container should sleep.",
+                                        "properties": {
+                                          "seconds": {
+                                            "description": "Seconds is the number of seconds to sleep.",
+                                            "format": "int64",
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "required": [
+                                          "seconds"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "tcpSocket": {
+                                        "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
+                                        "properties": {
+                                          "host": {
+                                            "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "required": [
+                                          "port"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "stopSignal": {
+                                    "description": "StopSignal defines which signal will be sent to a container when it is being stopped.\nIf not specified, the default is defined by the container runtime in use.\nStopSignal can only be set for Pods with a non-empty .spec.os.name",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "livenessProbe": {
+                                "description": "Probes are not allowed for ephemeral containers.",
+                                "properties": {
+                                  "exec": {
+                                    "description": "Exec specifies a command to execute in the container.",
+                                    "properties": {
+                                      "command": {
+                                        "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "failureThreshold": {
+                                    "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                                    "properties": {
+                                      "port": {
+                                        "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "default": "",
+                                        "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "description": "HTTPGet specifies an HTTP GET request to perform.",
+                                    "properties": {
+                                      "host": {
+                                        "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                        "items": {
+                                          "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                          "properties": {
+                                            "name": {
+                                              "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "The header field value",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "path": {
+                                        "description": "Path to access on the HTTP server.",
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "initialDelaySeconds": {
+                                    "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "description": "TCPSocket specifies a connection to a TCP port.",
+                                    "properties": {
+                                      "host": {
+                                        "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                                    "format": "int64",
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "name": {
+                                "description": "Name of the ephemeral container specified as a DNS_LABEL.\nThis name must be unique among all containers, init containers and ephemeral containers.",
+                                "type": "string"
+                              },
+                              "ports": {
+                                "description": "Ports are not allowed for ephemeral containers.",
+                                "items": {
+                                  "description": "ContainerPort represents a network port in a single container.",
+                                  "properties": {
+                                    "containerPort": {
+                                      "description": "Number of port to expose on the pod's IP address.\nThis must be a valid port number, 0 < x < 65536.",
+                                      "format": "int32",
+                                      "type": "integer"
+                                    },
+                                    "hostIP": {
+                                      "description": "What host IP to bind the external port to.",
+                                      "type": "string"
+                                    },
+                                    "hostPort": {
+                                      "description": "Number of port to expose on the host.\nIf specified, this must be a valid port number, 0 < x < 65536.\nIf HostNetwork is specified, this must match ContainerPort.\nMost containers do not need this.",
+                                      "format": "int32",
+                                      "type": "integer"
+                                    },
+                                    "name": {
+                                      "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each\nnamed port in a pod must have a unique name. Name for the port that can be\nreferred to by services.",
+                                      "type": "string"
+                                    },
+                                    "protocol": {
+                                      "default": "TCP",
+                                      "description": "Protocol for port. Must be UDP, TCP, or SCTP.\nDefaults to \"TCP\".",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "containerPort"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-map-keys": [
+                                  "containerPort",
+                                  "protocol"
+                                ],
+                                "x-kubernetes-list-type": "map"
+                              },
+                              "readinessProbe": {
+                                "description": "Probes are not allowed for ephemeral containers.",
+                                "properties": {
+                                  "exec": {
+                                    "description": "Exec specifies a command to execute in the container.",
+                                    "properties": {
+                                      "command": {
+                                        "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "failureThreshold": {
+                                    "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                                    "properties": {
+                                      "port": {
+                                        "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "default": "",
+                                        "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "description": "HTTPGet specifies an HTTP GET request to perform.",
+                                    "properties": {
+                                      "host": {
+                                        "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                        "items": {
+                                          "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                          "properties": {
+                                            "name": {
+                                              "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "The header field value",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "path": {
+                                        "description": "Path to access on the HTTP server.",
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "initialDelaySeconds": {
+                                    "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "description": "TCPSocket specifies a connection to a TCP port.",
+                                    "properties": {
+                                      "host": {
+                                        "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                                    "format": "int64",
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "resizePolicy": {
+                                "description": "Resources resize policy for the container.",
+                                "items": {
+                                  "description": "ContainerResizePolicy represents resource resize policy for the container.",
+                                  "properties": {
+                                    "resourceName": {
+                                      "description": "Name of the resource to which this resource resize policy applies.\nSupported values: cpu, memory.",
+                                      "type": "string"
+                                    },
+                                    "restartPolicy": {
+                                      "description": "Restart policy to apply when specified resource is resized.\nIf not specified, it defaults to NotRequired.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "resourceName",
+                                    "restartPolicy"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "resources": {
+                                "description": "Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources\nalready allocated to the pod.",
+                                "properties": {
+                                  "claims": {
+                                    "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis field depends on the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                                    "items": {
+                                      "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                                      "properties": {
+                                        "name": {
+                                          "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                                          "type": "string"
+                                        },
+                                        "request": {
+                                          "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-map-keys": [
+                                      "name"
+                                    ],
+                                    "x-kubernetes-list-type": "map"
+                                  },
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "restartPolicy": {
+                                "description": "Restart policy for the container to manage the restart behavior of each\ncontainer within a pod.\nYou cannot set this field on ephemeral containers.",
+                                "type": "string"
+                              },
+                              "restartPolicyRules": {
+                                "description": "Represents a list of rules to be checked to determine if the\ncontainer should be restarted on exit. You cannot set this field on\nephemeral containers.",
+                                "items": {
+                                  "description": "ContainerRestartRule describes how a container exit is handled.",
+                                  "properties": {
+                                    "action": {
+                                      "description": "Specifies the action taken on a container exit if the requirements\nare satisfied. The only possible value is \"Restart\" to restart the\ncontainer.",
+                                      "type": "string"
+                                    },
+                                    "exitCodes": {
+                                      "description": "Represents the exit codes to check on container exits.",
+                                      "properties": {
+                                        "operator": {
+                                          "description": "Represents the relationship between the container exit code(s) and the\nspecified values. Possible values are:\n- In: the requirement is satisfied if the container exit code is in the\n  set of specified values.\n- NotIn: the requirement is satisfied if the container exit code is\n  not in the set of specified values.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "Specifies the set of values to check for container exit codes.\nAt most 255 elements are allowed.",
+                                          "items": {
+                                            "format": "int32",
+                                            "type": "integer"
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "set"
+                                        }
+                                      },
+                                      "required": [
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": [
+                                    "action"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "securityContext": {
+                                "description": "Optional: SecurityContext defines the security options the ephemeral container should be run with.\nIf set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.",
+                                "properties": {
+                                  "allowPrivilegeEscalation": {
+                                    "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "type": "boolean"
+                                  },
+                                  "appArmorProfile": {
+                                    "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "type"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "capabilities": {
+                                    "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "properties": {
+                                      "add": {
+                                        "description": "Added capabilities",
+                                        "items": {
+                                          "description": "Capability represent POSIX capabilities type",
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "drop": {
+                                        "description": "Removed capabilities",
+                                        "items": {
+                                          "description": "Capability represent POSIX capabilities type",
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "privileged": {
+                                    "description": "Run container in privileged mode.\nProcesses in privileged containers are essentially equivalent to root on the host.\nDefaults to false.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "type": "boolean"
+                                  },
+                                  "procMount": {
+                                    "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "type": "string"
+                                  },
+                                  "readOnlyRootFilesystem": {
+                                    "description": "Whether this container has a read-only root filesystem.\nDefault is false.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "type": "boolean"
+                                  },
+                                  "runAsGroup": {
+                                    "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "format": "int64",
+                                    "type": "integer"
+                                  },
+                                  "runAsNonRoot": {
+                                    "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                    "type": "boolean"
+                                  },
+                                  "runAsUser": {
+                                    "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "format": "int64",
+                                    "type": "integer"
+                                  },
+                                  "seLinuxOptions": {
+                                    "description": "The SELinux context to be applied to the container.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "properties": {
+                                      "level": {
+                                        "description": "Level is SELinux level label that applies to the container.",
+                                        "type": "string"
+                                      },
+                                      "role": {
+                                        "description": "Role is a SELinux role label that applies to the container.",
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "description": "Type is a SELinux type label that applies to the container.",
+                                        "type": "string"
+                                      },
+                                      "user": {
+                                        "description": "User is a SELinux user label that applies to the container.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "seccompProfile": {
+                                    "description": "The seccomp options to use by this container. If seccomp options are\nprovided at both the pod & container level, the container options\noverride the pod options.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "type"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "windowsOptions": {
+                                    "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options from the PodSecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
+                                    "properties": {
+                                      "gmsaCredentialSpec": {
+                                        "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
+                                        "type": "string"
+                                      },
+                                      "gmsaCredentialSpecName": {
+                                        "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                                        "type": "string"
+                                      },
+                                      "hostProcess": {
+                                        "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                                        "type": "boolean"
+                                      },
+                                      "runAsUserName": {
+                                        "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "startupProbe": {
+                                "description": "Probes are not allowed for ephemeral containers.",
+                                "properties": {
+                                  "exec": {
+                                    "description": "Exec specifies a command to execute in the container.",
+                                    "properties": {
+                                      "command": {
+                                        "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "failureThreshold": {
+                                    "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                                    "properties": {
+                                      "port": {
+                                        "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "default": "",
+                                        "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "description": "HTTPGet specifies an HTTP GET request to perform.",
+                                    "properties": {
+                                      "host": {
+                                        "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                        "items": {
+                                          "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                          "properties": {
+                                            "name": {
+                                              "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "The header field value",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "path": {
+                                        "description": "Path to access on the HTTP server.",
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "initialDelaySeconds": {
+                                    "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "description": "TCPSocket specifies a connection to a TCP port.",
+                                    "properties": {
+                                      "host": {
+                                        "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                                    "format": "int64",
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "stdin": {
+                                "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this\nis not set, reads from stdin in the container will always result in EOF.\nDefault is false.",
+                                "type": "boolean"
+                              },
+                              "stdinOnce": {
+                                "description": "Whether the container runtime should close the stdin channel after it has been opened by\na single attach. When stdin is true the stdin stream will remain open across multiple attach\nsessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the\nfirst client attaches to stdin, and then remains open and accepts data until the client disconnects,\nat which time stdin is closed and remains closed until the container is restarted. If this\nflag is false, a container processes that reads from stdin will never receive an EOF.\nDefault is false",
+                                "type": "boolean"
+                              },
+                              "targetContainerName": {
+                                "description": "If set, the name of the container from PodSpec that this ephemeral container targets.\nThe ephemeral container will be run in the namespaces (IPC, PID, etc) of this container.\nIf not set then the ephemeral container uses the namespaces configured in the Pod spec.\n\nThe container runtime must implement support for this feature. If the runtime does not\nsupport namespace targeting then the result of setting this field is undefined.",
+                                "type": "string"
+                              },
+                              "terminationMessagePath": {
+                                "description": "Optional: Path at which the file to which the container's termination message\nwill be written is mounted into the container's filesystem.\nMessage written is intended to be brief final status, such as an assertion failure message.\nWill be truncated by the node if greater than 4096 bytes. The total message length across\nall containers will be limited to 12kb.\nDefaults to /dev/termination-log.\nCannot be updated.",
+                                "type": "string"
+                              },
+                              "terminationMessagePolicy": {
+                                "description": "Indicate how the termination message should be populated. File will use the contents of\nterminationMessagePath to populate the container status message on both success and failure.\nFallbackToLogsOnError will use the last chunk of container log output if the termination\nmessage file is empty and the container exited with an error.\nThe log output is limited to 2048 bytes or 80 lines, whichever is smaller.\nDefaults to File.\nCannot be updated.",
+                                "type": "string"
+                              },
+                              "tty": {
+                                "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.\nDefault is false.",
+                                "type": "boolean"
+                              },
+                              "volumeDevices": {
+                                "description": "volumeDevices is the list of block devices to be used by the container.",
+                                "items": {
+                                  "description": "volumeDevice describes a mapping of a raw block device within a container.",
+                                  "properties": {
+                                    "devicePath": {
+                                      "description": "devicePath is the path inside of the container that the device will be mapped to.",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "name must match the name of a persistentVolumeClaim in the pod",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "devicePath",
+                                    "name"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-map-keys": [
+                                  "devicePath"
+                                ],
+                                "x-kubernetes-list-type": "map"
+                              },
+                              "volumeMounts": {
+                                "description": "Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers.\nCannot be updated.",
+                                "items": {
+                                  "description": "VolumeMount describes a mounting of a Volume within a container.",
+                                  "properties": {
+                                    "mountPath": {
+                                      "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
+                                      "type": "string"
+                                    },
+                                    "mountPropagation": {
+                                      "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "This must match the Name of a Volume.",
+                                      "type": "string"
+                                    },
+                                    "readOnly": {
+                                      "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
+                                      "type": "boolean"
+                                    },
+                                    "recursiveReadOnly": {
+                                      "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                                      "type": "string"
+                                    },
+                                    "subPath": {
+                                      "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
+                                      "type": "string"
+                                    },
+                                    "subPathExpr": {
+                                      "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "mountPath",
+                                    "name"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-map-keys": [
+                                  "mountPath"
+                                ],
+                                "x-kubernetes-list-type": "map"
+                              },
+                              "workingDir": {
+                                "description": "Container's working directory.\nIf not specified, the container runtime's default will be used, which\nmight be configured in the container image.\nCannot be updated.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-map-keys": [
+                            "name"
+                          ],
+                          "x-kubernetes-list-type": "map"
+                        },
+                        "hostAliases": {
+                          "description": "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts\nfile if specified.",
+                          "items": {
+                            "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the\npod's hosts file.",
+                            "properties": {
+                              "hostnames": {
+                                "description": "Hostnames for the above IP address.",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "ip": {
+                                "description": "IP address of the host file entry.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "ip"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-map-keys": [
+                            "ip"
+                          ],
+                          "x-kubernetes-list-type": "map"
+                        },
+                        "hostIPC": {
+                          "description": "Use the host's ipc namespace.\nOptional: Default to false.",
+                          "type": "boolean"
+                        },
+                        "hostNetwork": {
+                          "description": "Host networking requested for this pod. Use the host's network namespace.\nWhen using HostNetwork you should specify ports so the scheduler is aware.\nWhen `hostNetwork` is true, specified `hostPort` fields in port definitions must match `containerPort`,\nand unspecified `hostPort` fields in port definitions are defaulted to match `containerPort`.\nDefault to false.",
+                          "type": "boolean"
+                        },
+                        "hostPID": {
+                          "description": "Use the host's pid namespace.\nOptional: Default to false.",
+                          "type": "boolean"
+                        },
+                        "hostUsers": {
+                          "description": "Use the host's user namespace.\nOptional: Default to true.\nIf set to true or not present, the pod will be run in the host user namespace, useful\nfor when the pod needs a feature only available to the host user namespace, such as\nloading a kernel module with CAP_SYS_MODULE.\nWhen set to false, a new userns is created for the pod. Setting false is useful for\nmitigating container breakout vulnerabilities even allowing users to run their\ncontainers as root without actually having root privileges on the host.\nThis field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.",
+                          "type": "boolean"
+                        },
+                        "hostname": {
+                          "description": "Specifies the hostname of the Pod\nIf not specified, the pod's hostname will be set to a system-defined value.",
+                          "type": "string"
+                        },
+                        "hostnameOverride": {
+                          "description": "HostnameOverride specifies an explicit override for the pod's hostname as perceived by the pod.\nThis field only specifies the pod's hostname and does not affect its DNS records.\nWhen this field is set to a non-empty string:\n- It takes precedence over the values set in `hostname` and `subdomain`.\n- The Pod's hostname will be set to this value.\n- `setHostnameAsFQDN` must be nil or set to false.\n- `hostNetwork` must be set to false.\n\nThis field must be a valid DNS subdomain as defined in RFC 1123 and contain at most 64 characters.\nRequires the HostnameOverride feature gate to be enabled.",
+                          "type": "string"
+                        },
+                        "imagePullSecrets": {
+                          "description": "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.\nIf specified, these secrets will be passed to individual puller implementations for them to use.\nMore info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod",
+                          "items": {
+                            "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                            "properties": {
+                              "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-map-keys": [
+                            "name"
+                          ],
+                          "x-kubernetes-list-type": "map"
+                        },
+                        "initContainers": {
+                          "description": "List of initialization containers belonging to the pod.\nInit containers are executed in order prior to containers being started. If any\ninit container fails, the pod is considered to have failed and is handled according\nto its restartPolicy. The name for an init container or normal container must be\nunique among all containers.\nInit containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.\nThe resourceRequirements of an init container are taken into account during scheduling\nby finding the highest request/limit for each resource type, and then using the max of\nthat value or the sum of the normal containers. Limits are applied to init containers\nin a similar fashion.\nInit containers cannot currently be added or removed.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/",
+                          "items": {
+                            "description": "A single application container that you want to run within a pod.",
+                            "properties": {
+                              "args": {
+                                "description": "Arguments to the entrypoint.\nThe container image's CMD is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "command": {
+                                "description": "Entrypoint array. Not executed within a shell.\nThe container image's ENTRYPOINT is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "env": {
+                                "description": "List of environment variables to set in the container.\nCannot be updated.",
+                                "items": {
+                                  "description": "EnvVar represents an environment variable present in a Container.",
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name of the environment variable.\nMay consist of any printable ASCII characters except '='.",
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
+                                      "type": "string"
+                                    },
+                                    "valueFrom": {
+                                      "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                                      "properties": {
+                                        "configMapKeyRef": {
+                                          "description": "Selects a key of a ConfigMap.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key to select.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "description": "Specify whether the ConfigMap or its key must be defined",
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "fieldRef": {
+                                          "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                                          "properties": {
+                                            "apiVersion": {
+                                              "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                              "type": "string"
+                                            },
+                                            "fieldPath": {
+                                              "description": "Path of the field to select in the specified API version.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "fieldPath"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "fileKeyRef": {
+                                          "description": "FileKeyRef selects a key of the env file.\nRequires the EnvFiles feature gate to be enabled.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key within the env file. An invalid key will prevent the pod from starting.\nThe keys defined within a source may consist of any printable ASCII characters except '='.\nDuring Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "default": false,
+                                              "description": "Specify whether the file or its key must be defined. If the file or key\ndoes not exist, then the env var is not published.\nIf optional is set to true and the specified key does not exist,\nthe environment variable will not be set in the Pod's containers.\n\nIf optional is set to false and the specified key does not exist,\nan error will be returned during Pod creation.",
+                                              "type": "boolean"
+                                            },
+                                            "path": {
+                                              "description": "The path within the volume from which to select the file.\nMust be relative and may not contain the '..' path or start with '..'.",
+                                              "type": "string"
+                                            },
+                                            "volumeName": {
+                                              "description": "The name of the volume mount containing the env file.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "path",
+                                            "volumeName"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "resourceFieldRef": {
+                                          "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                                          "properties": {
+                                            "containerName": {
+                                              "description": "Container name: required for volumes, optional for env vars",
+                                              "type": "string"
+                                            },
+                                            "divisor": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "resource": {
+                                              "description": "Required: resource to select",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "resource"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "secretKeyRef": {
+                                          "description": "Selects a key of a secret in the pod's namespace",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "description": "Specify whether the Secret or its key must be defined",
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": [
+                                    "name"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-map-keys": [
+                                  "name"
+                                ],
+                                "x-kubernetes-list-type": "map"
+                              },
+                              "envFrom": {
+                                "description": "List of sources to populate environment variables in the container.\nThe keys defined within a source may consist of any printable ASCII characters except '='.\nWhen a key exists in multiple\nsources, the value associated with the last source will take precedence.\nValues defined by an Env with a duplicate key will take precedence.\nCannot be updated.",
+                                "items": {
+                                  "description": "EnvFromSource represents the source of a set of ConfigMaps or Secrets",
+                                  "properties": {
+                                    "configMapRef": {
+                                      "description": "The ConfigMap to select from",
+                                      "properties": {
+                                        "name": {
+                                          "default": "",
+                                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "description": "Specify whether the ConfigMap must be defined",
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "prefix": {
+                                      "description": "Optional text to prepend to the name of each environment variable.\nMay consist of any printable ASCII characters except '='.",
+                                      "type": "string"
+                                    },
+                                    "secretRef": {
+                                      "description": "The Secret to select from",
+                                      "properties": {
+                                        "name": {
+                                          "default": "",
+                                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "description": "Specify whether the Secret must be defined",
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "image": {
+                                "description": "Container image name.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.",
+                                "type": "string"
+                              },
+                              "imagePullPolicy": {
+                                "description": "Image pull policy.\nOne of Always, Never, IfNotPresent.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+                                "type": "string"
+                              },
+                              "lifecycle": {
+                                "description": "Actions that the management system should take in response to container lifecycle events.\nCannot be updated.",
+                                "properties": {
+                                  "postStart": {
+                                    "description": "PostStart is called immediately after a container is created. If the handler fails,\nthe container is terminated and restarted according to its restart policy.\nOther management of the container blocks until the hook completes.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                                    "properties": {
+                                      "exec": {
+                                        "description": "Exec specifies a command to execute in the container.",
+                                        "properties": {
+                                          "command": {
+                                            "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "description": "HTTPGet specifies an HTTP GET request to perform.",
+                                        "properties": {
+                                          "host": {
+                                            "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                            "items": {
+                                              "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                              "properties": {
+                                                "name": {
+                                                  "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "description": "The header field value",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "name",
+                                                "value"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          },
+                                          "path": {
+                                            "description": "Path to access on the HTTP server.",
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "port"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "sleep": {
+                                        "description": "Sleep represents a duration that the container should sleep.",
+                                        "properties": {
+                                          "seconds": {
+                                            "description": "Seconds is the number of seconds to sleep.",
+                                            "format": "int64",
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "required": [
+                                          "seconds"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "tcpSocket": {
+                                        "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
+                                        "properties": {
+                                          "host": {
+                                            "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "required": [
+                                          "port"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "preStop": {
+                                    "description": "PreStop is called immediately before a container is terminated due to an\nAPI request or management event such as liveness/startup probe failure,\npreemption, resource contention, etc. The handler is not called if the\ncontainer crashes or exits. The Pod's termination grace period countdown begins before the\nPreStop hook is executed. Regardless of the outcome of the handler, the\ncontainer will eventually terminate within the Pod's termination grace\nperiod (unless delayed by finalizers). Other management of the container blocks until the hook completes\nor until the termination grace period is reached.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                                    "properties": {
+                                      "exec": {
+                                        "description": "Exec specifies a command to execute in the container.",
+                                        "properties": {
+                                          "command": {
+                                            "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "description": "HTTPGet specifies an HTTP GET request to perform.",
+                                        "properties": {
+                                          "host": {
+                                            "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                            "items": {
+                                              "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                              "properties": {
+                                                "name": {
+                                                  "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "description": "The header field value",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "name",
+                                                "value"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          },
+                                          "path": {
+                                            "description": "Path to access on the HTTP server.",
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "port"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "sleep": {
+                                        "description": "Sleep represents a duration that the container should sleep.",
+                                        "properties": {
+                                          "seconds": {
+                                            "description": "Seconds is the number of seconds to sleep.",
+                                            "format": "int64",
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "required": [
+                                          "seconds"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "tcpSocket": {
+                                        "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
+                                        "properties": {
+                                          "host": {
+                                            "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "required": [
+                                          "port"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "stopSignal": {
+                                    "description": "StopSignal defines which signal will be sent to a container when it is being stopped.\nIf not specified, the default is defined by the container runtime in use.\nStopSignal can only be set for Pods with a non-empty .spec.os.name",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "livenessProbe": {
+                                "description": "Periodic probe of container liveness.\nContainer will be restarted if the probe fails.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                "properties": {
+                                  "exec": {
+                                    "description": "Exec specifies a command to execute in the container.",
+                                    "properties": {
+                                      "command": {
+                                        "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "failureThreshold": {
+                                    "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                                    "properties": {
+                                      "port": {
+                                        "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "default": "",
+                                        "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "description": "HTTPGet specifies an HTTP GET request to perform.",
+                                    "properties": {
+                                      "host": {
+                                        "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                        "items": {
+                                          "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                          "properties": {
+                                            "name": {
+                                              "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "The header field value",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "path": {
+                                        "description": "Path to access on the HTTP server.",
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "initialDelaySeconds": {
+                                    "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "description": "TCPSocket specifies a connection to a TCP port.",
+                                    "properties": {
+                                      "host": {
+                                        "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                                    "format": "int64",
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "name": {
+                                "description": "Name of the container specified as a DNS_LABEL.\nEach container in a pod must have a unique name (DNS_LABEL).\nCannot be updated.",
+                                "type": "string"
+                              },
+                              "ports": {
+                                "description": "List of ports to expose from the container. Not specifying a port here\nDOES NOT prevent that port from being exposed. Any port which is\nlistening on the default \"0.0.0.0\" address inside a container will be\naccessible from the network.\nModifying this array with strategic merge patch may corrupt the data.\nFor more information See https://github.com/kubernetes/kubernetes/issues/108255.\nCannot be updated.",
+                                "items": {
+                                  "description": "ContainerPort represents a network port in a single container.",
+                                  "properties": {
+                                    "containerPort": {
+                                      "description": "Number of port to expose on the pod's IP address.\nThis must be a valid port number, 0 < x < 65536.",
+                                      "format": "int32",
+                                      "type": "integer"
+                                    },
+                                    "hostIP": {
+                                      "description": "What host IP to bind the external port to.",
+                                      "type": "string"
+                                    },
+                                    "hostPort": {
+                                      "description": "Number of port to expose on the host.\nIf specified, this must be a valid port number, 0 < x < 65536.\nIf HostNetwork is specified, this must match ContainerPort.\nMost containers do not need this.",
+                                      "format": "int32",
+                                      "type": "integer"
+                                    },
+                                    "name": {
+                                      "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each\nnamed port in a pod must have a unique name. Name for the port that can be\nreferred to by services.",
+                                      "type": "string"
+                                    },
+                                    "protocol": {
+                                      "default": "TCP",
+                                      "description": "Protocol for port. Must be UDP, TCP, or SCTP.\nDefaults to \"TCP\".",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "containerPort"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-map-keys": [
+                                  "containerPort",
+                                  "protocol"
+                                ],
+                                "x-kubernetes-list-type": "map"
+                              },
+                              "readinessProbe": {
+                                "description": "Periodic probe of container service readiness.\nContainer will be removed from service endpoints if the probe fails.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                "properties": {
+                                  "exec": {
+                                    "description": "Exec specifies a command to execute in the container.",
+                                    "properties": {
+                                      "command": {
+                                        "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "failureThreshold": {
+                                    "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                                    "properties": {
+                                      "port": {
+                                        "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "default": "",
+                                        "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "description": "HTTPGet specifies an HTTP GET request to perform.",
+                                    "properties": {
+                                      "host": {
+                                        "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                        "items": {
+                                          "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                          "properties": {
+                                            "name": {
+                                              "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "The header field value",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "path": {
+                                        "description": "Path to access on the HTTP server.",
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "initialDelaySeconds": {
+                                    "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "description": "TCPSocket specifies a connection to a TCP port.",
+                                    "properties": {
+                                      "host": {
+                                        "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                                    "format": "int64",
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "resizePolicy": {
+                                "description": "Resources resize policy for the container.",
+                                "items": {
+                                  "description": "ContainerResizePolicy represents resource resize policy for the container.",
+                                  "properties": {
+                                    "resourceName": {
+                                      "description": "Name of the resource to which this resource resize policy applies.\nSupported values: cpu, memory.",
+                                      "type": "string"
+                                    },
+                                    "restartPolicy": {
+                                      "description": "Restart policy to apply when specified resource is resized.\nIf not specified, it defaults to NotRequired.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "resourceName",
+                                    "restartPolicy"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "resources": {
+                                "description": "Compute Resources required by this container.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                "properties": {
+                                  "claims": {
+                                    "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis field depends on the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                                    "items": {
+                                      "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                                      "properties": {
+                                        "name": {
+                                          "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                                          "type": "string"
+                                        },
+                                        "request": {
+                                          "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-map-keys": [
+                                      "name"
+                                    ],
+                                    "x-kubernetes-list-type": "map"
+                                  },
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "restartPolicy": {
+                                "description": "RestartPolicy defines the restart behavior of individual containers in a pod.\nThis overrides the pod-level restart policy. When this field is not specified,\nthe restart behavior is defined by the Pod's restart policy and the container type.\nAdditionally, setting the RestartPolicy as \"Always\" for the init container will\nhave the following effect:\nthis init container will be continually restarted on\nexit until all regular containers have terminated. Once all regular\ncontainers have completed, all init containers with restartPolicy \"Always\"\nwill be shut down. This lifecycle differs from normal init containers and\nis often referred to as a \"sidecar\" container. Although this init\ncontainer still starts in the init container sequence, it does not wait\nfor the container to complete before proceeding to the next init\ncontainer. Instead, the next init container starts immediately after this\ninit container is started, or after any startupProbe has successfully\ncompleted.",
+                                "type": "string"
+                              },
+                              "restartPolicyRules": {
+                                "description": "Represents a list of rules to be checked to determine if the\ncontainer should be restarted on exit. The rules are evaluated in\norder. Once a rule matches a container exit condition, the remaining\nrules are ignored. If no rule matches the container exit condition,\nthe Container-level restart policy determines the whether the container\nis restarted or not. Constraints on the rules:\n- At most 20 rules are allowed.\n- Rules can have the same action.\n- Identical rules are not forbidden in validations.\nWhen rules are specified, container MUST set RestartPolicy explicitly\neven it if matches the Pod's RestartPolicy.",
+                                "items": {
+                                  "description": "ContainerRestartRule describes how a container exit is handled.",
+                                  "properties": {
+                                    "action": {
+                                      "description": "Specifies the action taken on a container exit if the requirements\nare satisfied. The only possible value is \"Restart\" to restart the\ncontainer.",
+                                      "type": "string"
+                                    },
+                                    "exitCodes": {
+                                      "description": "Represents the exit codes to check on container exits.",
+                                      "properties": {
+                                        "operator": {
+                                          "description": "Represents the relationship between the container exit code(s) and the\nspecified values. Possible values are:\n- In: the requirement is satisfied if the container exit code is in the\n  set of specified values.\n- NotIn: the requirement is satisfied if the container exit code is\n  not in the set of specified values.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "Specifies the set of values to check for container exit codes.\nAt most 255 elements are allowed.",
+                                          "items": {
+                                            "format": "int32",
+                                            "type": "integer"
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "set"
+                                        }
+                                      },
+                                      "required": [
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": [
+                                    "action"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "securityContext": {
+                                "description": "SecurityContext defines the security options the container should be run with.\nIf set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.\nMore info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
+                                "properties": {
+                                  "allowPrivilegeEscalation": {
+                                    "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "type": "boolean"
+                                  },
+                                  "appArmorProfile": {
+                                    "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "type"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "capabilities": {
+                                    "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "properties": {
+                                      "add": {
+                                        "description": "Added capabilities",
+                                        "items": {
+                                          "description": "Capability represent POSIX capabilities type",
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "drop": {
+                                        "description": "Removed capabilities",
+                                        "items": {
+                                          "description": "Capability represent POSIX capabilities type",
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "privileged": {
+                                    "description": "Run container in privileged mode.\nProcesses in privileged containers are essentially equivalent to root on the host.\nDefaults to false.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "type": "boolean"
+                                  },
+                                  "procMount": {
+                                    "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "type": "string"
+                                  },
+                                  "readOnlyRootFilesystem": {
+                                    "description": "Whether this container has a read-only root filesystem.\nDefault is false.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "type": "boolean"
+                                  },
+                                  "runAsGroup": {
+                                    "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "format": "int64",
+                                    "type": "integer"
+                                  },
+                                  "runAsNonRoot": {
+                                    "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                    "type": "boolean"
+                                  },
+                                  "runAsUser": {
+                                    "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "format": "int64",
+                                    "type": "integer"
+                                  },
+                                  "seLinuxOptions": {
+                                    "description": "The SELinux context to be applied to the container.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "properties": {
+                                      "level": {
+                                        "description": "Level is SELinux level label that applies to the container.",
+                                        "type": "string"
+                                      },
+                                      "role": {
+                                        "description": "Role is a SELinux role label that applies to the container.",
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "description": "Type is a SELinux type label that applies to the container.",
+                                        "type": "string"
+                                      },
+                                      "user": {
+                                        "description": "User is a SELinux user label that applies to the container.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "seccompProfile": {
+                                    "description": "The seccomp options to use by this container. If seccomp options are\nprovided at both the pod & container level, the container options\noverride the pod options.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "type"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "windowsOptions": {
+                                    "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options from the PodSecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
+                                    "properties": {
+                                      "gmsaCredentialSpec": {
+                                        "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
+                                        "type": "string"
+                                      },
+                                      "gmsaCredentialSpecName": {
+                                        "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                                        "type": "string"
+                                      },
+                                      "hostProcess": {
+                                        "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                                        "type": "boolean"
+                                      },
+                                      "runAsUserName": {
+                                        "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "startupProbe": {
+                                "description": "StartupProbe indicates that the Pod has successfully initialized.\nIf specified, no other probes are executed until this completes successfully.\nIf this probe fails, the Pod will be restarted, just as if the livenessProbe failed.\nThis can be used to provide different probe parameters at the beginning of a Pod's lifecycle,\nwhen it might take a long time to load data or warm a cache, than during steady-state operation.\nThis cannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                "properties": {
+                                  "exec": {
+                                    "description": "Exec specifies a command to execute in the container.",
+                                    "properties": {
+                                      "command": {
+                                        "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "failureThreshold": {
+                                    "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                                    "properties": {
+                                      "port": {
+                                        "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "default": "",
+                                        "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "description": "HTTPGet specifies an HTTP GET request to perform.",
+                                    "properties": {
+                                      "host": {
+                                        "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                        "items": {
+                                          "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                          "properties": {
+                                            "name": {
+                                              "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "The header field value",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "path": {
+                                        "description": "Path to access on the HTTP server.",
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "initialDelaySeconds": {
+                                    "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "description": "TCPSocket specifies a connection to a TCP port.",
+                                    "properties": {
+                                      "host": {
+                                        "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                                    "format": "int64",
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "stdin": {
+                                "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this\nis not set, reads from stdin in the container will always result in EOF.\nDefault is false.",
+                                "type": "boolean"
+                              },
+                              "stdinOnce": {
+                                "description": "Whether the container runtime should close the stdin channel after it has been opened by\na single attach. When stdin is true the stdin stream will remain open across multiple attach\nsessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the\nfirst client attaches to stdin, and then remains open and accepts data until the client disconnects,\nat which time stdin is closed and remains closed until the container is restarted. If this\nflag is false, a container processes that reads from stdin will never receive an EOF.\nDefault is false",
+                                "type": "boolean"
+                              },
+                              "terminationMessagePath": {
+                                "description": "Optional: Path at which the file to which the container's termination message\nwill be written is mounted into the container's filesystem.\nMessage written is intended to be brief final status, such as an assertion failure message.\nWill be truncated by the node if greater than 4096 bytes. The total message length across\nall containers will be limited to 12kb.\nDefaults to /dev/termination-log.\nCannot be updated.",
+                                "type": "string"
+                              },
+                              "terminationMessagePolicy": {
+                                "description": "Indicate how the termination message should be populated. File will use the contents of\nterminationMessagePath to populate the container status message on both success and failure.\nFallbackToLogsOnError will use the last chunk of container log output if the termination\nmessage file is empty and the container exited with an error.\nThe log output is limited to 2048 bytes or 80 lines, whichever is smaller.\nDefaults to File.\nCannot be updated.",
+                                "type": "string"
+                              },
+                              "tty": {
+                                "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.\nDefault is false.",
+                                "type": "boolean"
+                              },
+                              "volumeDevices": {
+                                "description": "volumeDevices is the list of block devices to be used by the container.",
+                                "items": {
+                                  "description": "volumeDevice describes a mapping of a raw block device within a container.",
+                                  "properties": {
+                                    "devicePath": {
+                                      "description": "devicePath is the path inside of the container that the device will be mapped to.",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "name must match the name of a persistentVolumeClaim in the pod",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "devicePath",
+                                    "name"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-map-keys": [
+                                  "devicePath"
+                                ],
+                                "x-kubernetes-list-type": "map"
+                              },
+                              "volumeMounts": {
+                                "description": "Pod volumes to mount into the container's filesystem.\nCannot be updated.",
+                                "items": {
+                                  "description": "VolumeMount describes a mounting of a Volume within a container.",
+                                  "properties": {
+                                    "mountPath": {
+                                      "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
+                                      "type": "string"
+                                    },
+                                    "mountPropagation": {
+                                      "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "This must match the Name of a Volume.",
+                                      "type": "string"
+                                    },
+                                    "readOnly": {
+                                      "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
+                                      "type": "boolean"
+                                    },
+                                    "recursiveReadOnly": {
+                                      "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                                      "type": "string"
+                                    },
+                                    "subPath": {
+                                      "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
+                                      "type": "string"
+                                    },
+                                    "subPathExpr": {
+                                      "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "mountPath",
+                                    "name"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-map-keys": [
+                                  "mountPath"
+                                ],
+                                "x-kubernetes-list-type": "map"
+                              },
+                              "workingDir": {
+                                "description": "Container's working directory.\nIf not specified, the container runtime's default will be used, which\nmight be configured in the container image.\nCannot be updated.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-map-keys": [
+                            "name"
+                          ],
+                          "x-kubernetes-list-type": "map"
+                        },
+                        "nodeName": {
+                          "description": "NodeName indicates in which node this pod is scheduled.\nIf empty, this pod is a candidate for scheduling by the scheduler defined in schedulerName.\nOnce this field is set, the kubelet for this node becomes responsible for the lifecycle of this pod.\nThis field should not be used to express a desire for the pod to be scheduled on a specific node.\nhttps://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodename",
+                          "type": "string"
+                        },
+                        "nodeSelector": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "NodeSelector is a selector which must be true for the pod to fit on a node.\nSelector which must match a node's labels for the pod to be scheduled on that node.\nMore info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic"
+                        },
+                        "os": {
+                          "description": "Specifies the OS of the containers in the pod.\nSome pod and container fields are restricted if this is set.\n\nIf the OS field is set to linux, the following fields must be unset:\n-securityContext.windowsOptions\n\nIf the OS field is set to windows, following fields must be unset:\n- spec.hostPID\n- spec.hostIPC\n- spec.hostUsers\n- spec.resources\n- spec.securityContext.appArmorProfile\n- spec.securityContext.seLinuxOptions\n- spec.securityContext.seccompProfile\n- spec.securityContext.fsGroup\n- spec.securityContext.fsGroupChangePolicy\n- spec.securityContext.sysctls\n- spec.shareProcessNamespace\n- spec.securityContext.runAsUser\n- spec.securityContext.runAsGroup\n- spec.securityContext.supplementalGroups\n- spec.securityContext.supplementalGroupsPolicy\n- spec.containers[*].securityContext.appArmorProfile\n- spec.containers[*].securityContext.seLinuxOptions\n- spec.containers[*].securityContext.seccompProfile\n- spec.containers[*].securityContext.capabilities\n- spec.containers[*].securityContext.readOnlyRootFilesystem\n- spec.containers[*].securityContext.privileged\n- spec.containers[*].securityContext.allowPrivilegeEscalation\n- spec.containers[*].securityContext.procMount\n- spec.containers[*].securityContext.runAsUser\n- spec.containers[*].securityContext.runAsGroup",
+                          "properties": {
+                            "name": {
+                              "description": "Name is the name of the operating system. The currently supported values are linux and windows.\nAdditional value may be defined in future and can be one of:\nhttps://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration\nClients should expect to handle additional values and treat unrecognized values in this field as os: null",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "overhead": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "description": "Overhead represents the resource overhead associated with running a pod for a given RuntimeClass.\nThis field will be autopopulated at admission time by the RuntimeClass admission controller. If\nthe RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests.\nThe RuntimeClass admission controller will reject Pod create requests which have the overhead already\nset. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value\ndefined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero.\nMore info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md",
+                          "type": "object"
+                        },
+                        "preemptionPolicy": {
+                          "description": "PreemptionPolicy is the Policy for preempting pods with lower priority.\nOne of Never, PreemptLowerPriority.\nDefaults to PreemptLowerPriority if unset.",
+                          "type": "string"
+                        },
+                        "priority": {
+                          "description": "The priority value. Various system components use this field to find the\npriority of the pod. When Priority Admission Controller is enabled, it\nprevents users from setting this field. The admission controller populates\nthis field from PriorityClassName.\nThe higher the value, the higher the priority.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "priorityClassName": {
+                          "description": "If specified, indicates the pod's priority. \"system-node-critical\" and\n\"system-cluster-critical\" are two special keywords which indicate the\nhighest priorities with the former being the highest priority. Any other\nname must be defined by creating a PriorityClass object with that name.\nIf not specified, the pod priority will be default or zero if there is no\ndefault.",
+                          "type": "string"
+                        },
+                        "readinessGates": {
+                          "description": "If specified, all readiness gates will be evaluated for pod readiness.\nA pod is ready when all its containers are ready AND\nall conditions specified in the readiness gates have status equal to \"True\"\nMore info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates",
+                          "items": {
+                            "description": "PodReadinessGate contains the reference to a pod condition",
+                            "properties": {
+                              "conditionType": {
+                                "description": "ConditionType refers to a condition in the pod's condition list with matching type.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "conditionType"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
+                        },
+                        "resourceClaims": {
+                          "description": "ResourceClaims defines which ResourceClaims must be allocated\nand reserved before the Pod is allowed to start. The resources\nwill be made available to those containers which consume them\nby name.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable.",
+                          "items": {
+                            "description": "PodResourceClaim references exactly one ResourceClaim, either directly\nor by naming a ResourceClaimTemplate which is then turned into a ResourceClaim\nfor the pod.\n\nIt adds a name to it that uniquely identifies the ResourceClaim inside the Pod.\nContainers that need access to the ResourceClaim reference it with this name.",
+                            "properties": {
+                              "name": {
+                                "description": "Name uniquely identifies this resource claim inside the pod.\nThis must be a DNS_LABEL.",
+                                "type": "string"
+                              },
+                              "resourceClaimName": {
+                                "description": "ResourceClaimName is the name of a ResourceClaim object in the same\nnamespace as this pod.\n\nExactly one of ResourceClaimName and ResourceClaimTemplateName must\nbe set.",
+                                "type": "string"
+                              },
+                              "resourceClaimTemplateName": {
+                                "description": "ResourceClaimTemplateName is the name of a ResourceClaimTemplate\nobject in the same namespace as this pod.\n\nThe template will be used to create a new ResourceClaim, which will\nbe bound to this pod. When this pod is deleted, the ResourceClaim\nwill also be deleted. The pod name and resource name, along with a\ngenerated component, will be used to form a unique name for the\nResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.\n\nThis field is immutable and no changes will be made to the\ncorresponding ResourceClaim by the control plane after creating the\nResourceClaim.\n\nExactly one of ResourceClaimName and ResourceClaimTemplateName must\nbe set.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-map-keys": [
+                            "name"
+                          ],
+                          "x-kubernetes-list-type": "map"
+                        },
+                        "resources": {
+                          "description": "Resources is the total amount of CPU and Memory resources required by all\ncontainers in the pod. It supports specifying Requests and Limits for\n\"cpu\", \"memory\" and \"hugepages-\" resource names only. ResourceClaims are not supported.\n\nThis field enables fine-grained control over resource allocation for the\nentire pod, allowing resource sharing among containers in a pod.\n\nThis is an alpha field and requires enabling the PodLevelResources feature\ngate.",
+                          "properties": {
+                            "claims": {
+                              "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis field depends on the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                              "items": {
+                                "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                                    "type": "string"
+                                  },
+                                  "request": {
+                                    "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-map-keys": [
+                                "name"
+                              ],
+                              "x-kubernetes-list-type": "map"
+                            },
+                            "limits": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                              "type": "object"
+                            },
+                            "requests": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "restartPolicy": {
+                          "description": "Restart policy for all containers within the pod.\nOne of Always, OnFailure, Never. In some contexts, only a subset of those values may be permitted.\nDefault to Always.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy",
+                          "type": "string"
+                        },
+                        "runtimeClassName": {
+                          "description": "RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used\nto run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run.\nIf unset or empty, the \"legacy\" RuntimeClass will be used, which is an implicit class with an\nempty definition that uses the default runtime handler.\nMore info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class",
+                          "type": "string"
+                        },
+                        "schedulerName": {
+                          "description": "If specified, the pod will be dispatched by specified scheduler.\nIf not specified, the pod will be dispatched by default scheduler.",
+                          "type": "string"
+                        },
+                        "schedulingGates": {
+                          "description": "SchedulingGates is an opaque list of values that if specified will block scheduling the pod.\nIf schedulingGates is not empty, the pod will stay in the SchedulingGated state and the\nscheduler will not attempt to schedule the pod.\n\nSchedulingGates can only be set at pod creation time, and be removed only afterwards.",
+                          "items": {
+                            "description": "PodSchedulingGate is associated to a Pod to guard its scheduling.",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the scheduling gate.\nEach scheduling gate must have a unique name field.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-map-keys": [
+                            "name"
+                          ],
+                          "x-kubernetes-list-type": "map"
+                        },
+                        "securityContext": {
+                          "description": "SecurityContext holds pod-level security attributes and common container settings.\nOptional: Defaults to empty.  See type description for default values of each field.",
+                          "properties": {
+                            "appArmorProfile": {
+                              "description": "appArmorProfile is the AppArmor options to use by the containers in this pod.\nNote that this field cannot be set when spec.os.name is windows.",
+                              "properties": {
+                                "localhostProfile": {
+                                  "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "type"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "fsGroup": {
+                              "description": "A special supplemental group that applies to all containers in a pod.\nSome volume types allow the Kubelet to change the ownership of that volume\nto be owned by the pod:\n\n1. The owning GID will be the FSGroup\n2. The setgid bit is set (new files created in the volume will be owned by FSGroup)\n3. The permission bits are OR'd with rw-rw----\n\nIf unset, the Kubelet will not modify the ownership and permissions of any volume.\nNote that this field cannot be set when spec.os.name is windows.",
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "fsGroupChangePolicy": {
+                              "description": "fsGroupChangePolicy defines behavior of changing ownership and permission of the volume\nbefore being exposed inside Pod. This field will only apply to\nvolume types which support fsGroup based ownership(and permissions).\nIt will have no effect on ephemeral volume types such as: secret, configmaps\nand emptydir.\nValid values are \"OnRootMismatch\" and \"Always\". If not specified, \"Always\" is used.\nNote that this field cannot be set when spec.os.name is windows.",
+                              "type": "string"
+                            },
+                            "runAsGroup": {
+                              "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence\nfor that container.\nNote that this field cannot be set when spec.os.name is windows.",
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "runAsNonRoot": {
+                              "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                              "type": "boolean"
+                            },
+                            "runAsUser": {
+                              "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence\nfor that container.\nNote that this field cannot be set when spec.os.name is windows.",
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "seLinuxChangePolicy": {
+                              "description": "seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.\nIt has no effect on nodes that do not support SELinux or to volumes does not support SELinux.\nValid values are \"MountOption\" and \"Recursive\".\n\n\"Recursive\" means relabeling of all files on all Pod volumes by the container runtime.\nThis may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.\n\n\"MountOption\" mounts all eligible Pod volumes with `-o context` mount option.\nThis requires all Pods that share the same volume to use the same SELinux label.\nIt is not possible to share the same volume among privileged and unprivileged Pods.\nEligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes\nwhose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their\nCSIDriver instance. Other volumes are always re-labelled recursively.\n\"MountOption\" value is allowed only when SELinuxMount feature gate is enabled.\n\nIf not specified and SELinuxMount feature gate is enabled, \"MountOption\" is used.\nIf not specified and SELinuxMount feature gate is disabled, \"MountOption\" is used for ReadWriteOncePod volumes\nand \"Recursive\" for all other volumes.\n\nThis field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.\n\nAll Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.\nNote that this field cannot be set when spec.os.name is windows.",
+                              "type": "string"
+                            },
+                            "seLinuxOptions": {
+                              "description": "The SELinux context to be applied to all containers.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in SecurityContext.  If set in\nboth SecurityContext and PodSecurityContext, the value specified in SecurityContext\ntakes precedence for that container.\nNote that this field cannot be set when spec.os.name is windows.",
+                              "properties": {
+                                "level": {
+                                  "description": "Level is SELinux level label that applies to the container.",
+                                  "type": "string"
+                                },
+                                "role": {
+                                  "description": "Role is a SELinux role label that applies to the container.",
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "description": "Type is a SELinux type label that applies to the container.",
+                                  "type": "string"
+                                },
+                                "user": {
+                                  "description": "User is a SELinux user label that applies to the container.",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "seccompProfile": {
+                              "description": "The seccomp options to use by the containers in this pod.\nNote that this field cannot be set when spec.os.name is windows.",
+                              "properties": {
+                                "localhostProfile": {
+                                  "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "type"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "supplementalGroups": {
+                              "description": "A list of groups applied to the first process run in each container, in\naddition to the container's primary GID and fsGroup (if specified).  If\nthe SupplementalGroupsPolicy feature is enabled, the\nsupplementalGroupsPolicy field determines whether these are in addition\nto or instead of any group memberships defined in the container image.\nIf unspecified, no additional groups are added, though group memberships\ndefined in the container image may still be used, depending on the\nsupplementalGroupsPolicy field.\nNote that this field cannot be set when spec.os.name is windows.",
+                              "items": {
+                                "format": "int64",
+                                "type": "integer"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "supplementalGroupsPolicy": {
+                              "description": "Defines how supplemental groups of the first container processes are calculated.\nValid values are \"Merge\" and \"Strict\". If not specified, \"Merge\" is used.\n(Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled\nand the container runtime must implement support for this feature.\nNote that this field cannot be set when spec.os.name is windows.",
+                              "type": "string"
+                            },
+                            "sysctls": {
+                              "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported\nsysctls (by the container runtime) might fail to launch.\nNote that this field cannot be set when spec.os.name is windows.",
+                              "items": {
+                                "description": "Sysctl defines a kernel parameter to be set",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name of a property to set",
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Value of a property to set",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "windowsOptions": {
+                              "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options within a container's SecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
+                              "properties": {
+                                "gmsaCredentialSpec": {
+                                  "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
+                                  "type": "string"
+                                },
+                                "gmsaCredentialSpecName": {
+                                  "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                                  "type": "string"
+                                },
+                                "hostProcess": {
+                                  "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                                  "type": "boolean"
+                                },
+                                "runAsUserName": {
+                                  "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "serviceAccount": {
+                          "description": "DeprecatedServiceAccount is a deprecated alias for ServiceAccountName.\nDeprecated: Use serviceAccountName instead.",
+                          "type": "string"
+                        },
+                        "serviceAccountName": {
+                          "description": "ServiceAccountName is the name of the ServiceAccount to use to run this pod.\nMore info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/",
+                          "type": "string"
+                        },
+                        "setHostnameAsFQDN": {
+                          "description": "If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default).\nIn Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname).\nIn Windows containers, this means setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\\\\SYSTEM\\\\CurrentControlSet\\\\Services\\\\Tcpip\\\\Parameters to FQDN.\nIf a pod does not have FQDN, this has no effect.\nDefault to false.",
+                          "type": "boolean"
+                        },
+                        "shareProcessNamespace": {
+                          "description": "Share a single process namespace between all of the containers in a pod.\nWhen this is set containers will be able to view and signal processes from other containers\nin the same pod, and the first process in each container will not be assigned PID 1.\nHostPID and ShareProcessNamespace cannot both be set.\nOptional: Default to false.",
+                          "type": "boolean"
+                        },
+                        "subdomain": {
+                          "description": "If specified, the fully qualified Pod hostname will be \"<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>\".\nIf not specified, the pod will not have a domainname at all.",
+                          "type": "string"
+                        },
+                        "terminationGracePeriodSeconds": {
+                          "description": "Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nIf this value is nil, the default grace period will be used instead.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nDefaults to 30 seconds.",
+                          "format": "int64",
+                          "type": "integer"
+                        },
+                        "tolerations": {
+                          "description": "If specified, the pod's tolerations.",
+                          "items": {
+                            "description": "The pod this Toleration is attached to tolerates any taint that matches\nthe triple <key,value,effect> using the matching operator <operator>.",
+                            "properties": {
+                              "effect": {
+                                "description": "Effect indicates the taint effect to match. Empty means match all taint effects.\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                                "type": "string"
+                              },
+                              "key": {
+                                "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys.\nIf the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                                "type": "string"
+                              },
+                              "operator": {
+                                "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.",
+                                "type": "string"
+                              },
+                              "tolerationSeconds": {
+                                "description": "TolerationSeconds represents the period of time the toleration (which must be\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\nit is not set, which means tolerate the taint forever (do not evict). Zero and\nnegative values will be treated as 0 (evict immediately) by the system.",
+                                "format": "int64",
+                                "type": "integer"
+                              },
+                              "value": {
+                                "description": "Value is the taint value the toleration matches to.\nIf the operator is Exists, the value should be empty, otherwise just a regular string.",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
+                        },
+                        "topologySpreadConstraints": {
+                          "description": "TopologySpreadConstraints describes how a group of pods ought to spread across topology\ndomains. Scheduler will schedule pods in a way which abides by the constraints.\nAll topologySpreadConstraints are ANDed.",
+                          "items": {
+                            "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
+                            "properties": {
+                              "labelSelector": {
+                                "description": "LabelSelector is used to find matching pods.\nPods that match this label selector are counted to determine the number of pods\nin their corresponding topology domain.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "matchLabelKeys": {
+                                "description": "MatchLabelKeys is a set of pod label keys to select the pods over which\nspreading will be calculated. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are ANDed with labelSelector\nto select the group of existing pods over which spreading will be calculated\nfor the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.\nMatchLabelKeys cannot be set when LabelSelector isn't set.\nKeys that don't exist in the incoming pod labels will\nbe ignored. A null or empty list means only match against labelSelector.\n\nThis is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "maxSkew": {
+                                "description": "MaxSkew describes the degree to which pods may be unevenly distributed.\nWhen `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference\nbetween the number of matching pods in the target topology and the global minimum.\nThe global minimum is the minimum number of matching pods in an eligible domain\nor zero if the number of eligible domains is less than MinDomains.\nFor example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same\nlabelSelector spread as 2/2/1:\nIn this case, the global minimum is 1.\n| zone1 | zone2 | zone3 |\n|  P P  |  P P  |   P   |\n- if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;\nscheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)\nviolate MaxSkew(1).\n- if MaxSkew is 2, incoming pod can be scheduled onto any zone.\nWhen `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence\nto topologies that satisfy it.\nIt's a required field. Default value is 1 and 0 is not allowed.",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "minDomains": {
+                                "description": "MinDomains indicates a minimum number of eligible domains.\nWhen the number of eligible domains with matching topology keys is less than minDomains,\nPod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed.\nAnd when the number of eligible domains with matching topology keys equals or greater than minDomains,\nthis value has no effect on scheduling.\nAs a result, when the number of eligible domains is less than minDomains,\nscheduler won't schedule more than maxSkew Pods to those domains.\nIf value is nil, the constraint behaves as if MinDomains is equal to 1.\nValid values are integers greater than 0.\nWhen value is not nil, WhenUnsatisfiable must be DoNotSchedule.\n\nFor example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same\nlabelSelector spread as 2/2/2:\n| zone1 | zone2 | zone3 |\n|  P P  |  P P  |  P P  |\nThe number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0.\nIn this situation, new pod with the same labelSelector cannot be scheduled,\nbecause computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,\nit will violate MaxSkew.",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "nodeAffinityPolicy": {
+                                "description": "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector\nwhen calculating pod topology spread skew. Options are:\n- Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.\n- Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.\n\nIf this value is nil, the behavior is equivalent to the Honor policy.",
+                                "type": "string"
+                              },
+                              "nodeTaintsPolicy": {
+                                "description": "NodeTaintsPolicy indicates how we will treat node taints when calculating\npod topology spread skew. Options are:\n- Honor: nodes without taints, along with tainted nodes for which the incoming pod\nhas a toleration, are included.\n- Ignore: node taints are ignored. All nodes are included.\n\nIf this value is nil, the behavior is equivalent to the Ignore policy.",
+                                "type": "string"
+                              },
+                              "topologyKey": {
+                                "description": "TopologyKey is the key of node labels. Nodes that have a label with this key\nand identical values are considered to be in the same topology.\nWe consider each <key, value> as a \"bucket\", and try to put balanced number\nof pods into each bucket.\nWe define a domain as a particular instance of a topology.\nAlso, we define an eligible domain as a domain whose nodes meet the requirements of\nnodeAffinityPolicy and nodeTaintsPolicy.\ne.g. If TopologyKey is \"kubernetes.io/hostname\", each Node is a domain of that topology.\nAnd, if TopologyKey is \"topology.kubernetes.io/zone\", each zone is a domain of that topology.\nIt's a required field.",
+                                "type": "string"
+                              },
+                              "whenUnsatisfiable": {
+                                "description": "WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy\nthe spread constraint.\n- DoNotSchedule (default) tells the scheduler not to schedule it.\n- ScheduleAnyway tells the scheduler to schedule the pod in any location,\n  but giving higher precedence to topologies that would help reduce the\n  skew.\nA constraint is considered \"Unsatisfiable\" for an incoming pod\nif and only if every possible node assignment for that pod would violate\n\"MaxSkew\" on some topology.\nFor example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same\nlabelSelector spread as 3/1/1:\n| zone1 | zone2 | zone3 |\n| P P P |   P   |   P   |\nIf WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled\nto zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies\nMaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler\nwon't make it *more* imbalanced.\nIt's a required field.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "maxSkew",
+                              "topologyKey",
+                              "whenUnsatisfiable"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-map-keys": [
+                            "topologyKey",
+                            "whenUnsatisfiable"
+                          ],
+                          "x-kubernetes-list-type": "map"
+                        },
+                        "volumes": {
+                          "description": "List of volumes that can be mounted by containers belonging to the pod.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes",
+                          "items": {
+                            "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
+                            "properties": {
+                              "awsElasticBlockStore": {
+                                "description": "awsElasticBlockStore represents an AWS Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nDeprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree\nawsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                                "properties": {
+                                  "fsType": {
+                                    "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                                    "type": "string"
+                                  },
+                                  "partition": {
+                                    "description": "partition is the partition in the volume that you want to mount.\nIf omitted, the default is to mount by volume name.\nExamples: For volume /dev/sda1, you specify the partition as \"1\".\nSimilarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "readOnly": {
+                                    "description": "readOnly value true will force the readOnly setting in VolumeMounts.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                                    "type": "boolean"
+                                  },
+                                  "volumeID": {
+                                    "description": "volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "volumeID"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "azureDisk": {
+                                "description": "azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.\nDeprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type\nare redirected to the disk.csi.azure.com CSI driver.",
+                                "properties": {
+                                  "cachingMode": {
+                                    "description": "cachingMode is the Host Caching mode: None, Read Only, Read Write.",
+                                    "type": "string"
+                                  },
+                                  "diskName": {
+                                    "description": "diskName is the Name of the data disk in the blob storage",
+                                    "type": "string"
+                                  },
+                                  "diskURI": {
+                                    "description": "diskURI is the URI of data disk in the blob storage",
+                                    "type": "string"
+                                  },
+                                  "fsType": {
+                                    "default": "ext4",
+                                    "description": "fsType is Filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "description": "kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "default": false,
+                                    "description": "readOnly Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "diskName",
+                                  "diskURI"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "azureFile": {
+                                "description": "azureFile represents an Azure File Service mount on the host and bind mount to the pod.\nDeprecated: AzureFile is deprecated. All operations for the in-tree azureFile type\nare redirected to the file.csi.azure.com CSI driver.",
+                                "properties": {
+                                  "readOnly": {
+                                    "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                                    "type": "boolean"
+                                  },
+                                  "secretName": {
+                                    "description": "secretName is the  name of secret that contains Azure Storage Account Name and Key",
+                                    "type": "string"
+                                  },
+                                  "shareName": {
+                                    "description": "shareName is the azure share Name",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "secretName",
+                                  "shareName"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "cephfs": {
+                                "description": "cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.\nDeprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.",
+                                "properties": {
+                                  "monitors": {
+                                    "description": "monitors is Required: Monitors is a collection of Ceph monitors\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "path": {
+                                    "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                                    "type": "boolean"
+                                  },
+                                  "secretFile": {
+                                    "description": "secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                                    "type": "string"
+                                  },
+                                  "secretRef": {
+                                    "description": "secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                                    "properties": {
+                                      "name": {
+                                        "default": "",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "user": {
+                                    "description": "user is optional: User is the rados user name, default is admin\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "monitors"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "cinder": {
+                                "description": "cinder represents a cinder volume attached and mounted on kubelets host machine.\nDeprecated: Cinder is deprecated. All operations for the in-tree cinder type\nare redirected to the cinder.csi.openstack.org CSI driver.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                                "properties": {
+                                  "fsType": {
+                                    "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "description": "secretRef is optional: points to a secret object containing parameters used to connect\nto OpenStack.",
+                                    "properties": {
+                                      "name": {
+                                        "default": "",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "volumeID": {
+                                    "description": "volumeID used to identify the volume in cinder.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "volumeID"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "configMap": {
+                                "description": "configMap represents a configMap that should populate this volume",
+                                "properties": {
+                                  "defaultMode": {
+                                    "description": "defaultMode is optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "items": {
+                                    "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                                    "items": {
+                                      "description": "Maps a string key to a path within a volume.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the key to project.",
+                                          "type": "string"
+                                        },
+                                        "mode": {
+                                          "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                          "format": "int32",
+                                          "type": "integer"
+                                        },
+                                        "path": {
+                                          "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "path"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "name": {
+                                    "default": "",
+                                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "description": "optional specify whether the ConfigMap or its keys must be defined",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "csi": {
+                                "description": "csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.",
+                                "properties": {
+                                  "driver": {
+                                    "description": "driver is the name of the CSI driver that handles this volume.\nConsult with your admin for the correct name as registered in the cluster.",
+                                    "type": "string"
+                                  },
+                                  "fsType": {
+                                    "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\".\nIf not provided, the empty value is passed to the associated CSI driver\nwhich will determine the default filesystem to apply.",
+                                    "type": "string"
+                                  },
+                                  "nodePublishSecretRef": {
+                                    "description": "nodePublishSecretRef is a reference to the secret object containing\nsensitive information to pass to the CSI driver to complete the CSI\nNodePublishVolume and NodeUnpublishVolume calls.\nThis field is optional, and  may be empty if no secret is required. If the\nsecret object contains more than one secret, all secret references are passed.",
+                                    "properties": {
+                                      "name": {
+                                        "default": "",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "readOnly": {
+                                    "description": "readOnly specifies a read-only configuration for the volume.\nDefaults to false (read/write).",
+                                    "type": "boolean"
+                                  },
+                                  "volumeAttributes": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "volumeAttributes stores driver-specific properties that are passed to the CSI\ndriver. Consult your driver's documentation for supported values.",
+                                    "type": "object"
+                                  }
+                                },
+                                "required": [
+                                  "driver"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "downwardAPI": {
+                                "description": "downwardAPI represents downward API about the pod that should populate this volume",
+                                "properties": {
+                                  "defaultMode": {
+                                    "description": "Optional: mode bits to use on created files by default. Must be a\nOptional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "items": {
+                                    "description": "Items is a list of downward API volume file",
+                                    "items": {
+                                      "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                      "properties": {
+                                        "fieldRef": {
+                                          "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
+                                          "properties": {
+                                            "apiVersion": {
+                                              "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                              "type": "string"
+                                            },
+                                            "fieldPath": {
+                                              "description": "Path of the field to select in the specified API version.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "fieldPath"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "mode": {
+                                          "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                          "format": "int32",
+                                          "type": "integer"
+                                        },
+                                        "path": {
+                                          "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                          "type": "string"
+                                        },
+                                        "resourceFieldRef": {
+                                          "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                          "properties": {
+                                            "containerName": {
+                                              "description": "Container name: required for volumes, optional for env vars",
+                                              "type": "string"
+                                            },
+                                            "divisor": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "resource": {
+                                              "description": "Required: resource to select",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "resource"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "required": [
+                                        "path"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "emptyDir": {
+                                "description": "emptyDir represents a temporary directory that shares a pod's lifetime.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                                "properties": {
+                                  "medium": {
+                                    "description": "medium represents what type of storage medium should back this directory.\nThe default is \"\" which means to use the node's default medium.\nMust be an empty string (default) or Memory.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                                    "type": "string"
+                                  },
+                                  "sizeLimit": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume.\nThe size limit is also applicable for memory medium.\nThe maximum usage on memory medium EmptyDir would be the minimum value between\nthe SizeLimit specified here and the sum of memory limits of all containers in a pod.\nThe default is nil which means that the limit is undefined.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "ephemeral": {
+                                "description": "ephemeral represents a volume that is handled by a cluster storage driver.\nThe volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,\nand deleted when the pod is removed.\n\nUse this if:\na) the volume is only needed while the pod runs,\nb) features of normal volumes like restoring from snapshot or capacity\n   tracking are needed,\nc) the storage driver is specified through a storage class, and\nd) the storage driver supports dynamic volume provisioning through\n   a PersistentVolumeClaim (see EphemeralVolumeSource for more\n   information on the connection between this volume type\n   and PersistentVolumeClaim).\n\nUse PersistentVolumeClaim or one of the vendor-specific\nAPIs for volumes that persist for longer than the lifecycle\nof an individual pod.\n\nUse CSI for light-weight local ephemeral volumes if the CSI driver is meant to\nbe used that way - see the documentation of the driver for\nmore information.\n\nA pod can use both types of ephemeral volumes and\npersistent volumes at the same time.",
+                                "properties": {
+                                  "volumeClaimTemplate": {
+                                    "description": "Will be used to create a stand-alone PVC to provision the volume.\nThe pod in which this EphemeralVolumeSource is embedded will be the\nowner of the PVC, i.e. the PVC will be deleted together with the\npod.  The name of the PVC will be `<pod name>-<volume name>` where\n`<volume name>` is the name from the `PodSpec.Volumes` array\nentry. Pod validation will reject the pod if the concatenated name\nis not valid for a PVC (for example, too long).\n\nAn existing PVC with that name that is not owned by the pod\nwill *not* be used for the pod to avoid using an unrelated\nvolume by mistake. Starting the pod is then blocked until\nthe unrelated PVC is removed. If such a pre-created PVC is\nmeant to be used by the pod, the PVC has to updated with an\nowner reference to the pod once the pod exists. Normally\nthis should not be necessary, but it may be useful when\nmanually reconstructing a broken cluster.\n\nThis field is read-only and no changes will be made by Kubernetes\nto the PVC after it has been created.\n\nRequired, must not be nil.",
+                                    "properties": {
+                                      "metadata": {
+                                        "description": "May contain labels and annotations that will be copied into the PVC\nwhen creating it. No other fields are allowed and will be rejected during\nvalidation.",
+                                        "type": "object"
+                                      },
+                                      "spec": {
+                                        "description": "The specification for the PersistentVolumeClaim. The entire content is\ncopied unchanged into the PVC that gets created from this\ntemplate. The same fields as in a PersistentVolumeClaim\nare also valid here.",
+                                        "properties": {
+                                          "accessModes": {
+                                            "description": "accessModes contains the desired access modes the volume should have.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          },
+                                          "dataSource": {
+                                            "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.\nWhen the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,\nand dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.\nIf the namespace is specified, then dataSourceRef will not be copied to dataSource.",
+                                            "properties": {
+                                              "apiGroup": {
+                                                "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "description": "Kind is the type of resource being referenced",
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "description": "Name is the name of resource being referenced",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "kind",
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "dataSourceRef": {
+                                            "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty\nvolume is desired. This may be any object from a non-empty API group (non\ncore object) or a PersistentVolumeClaim object.\nWhen this field is specified, volume binding will only succeed if the type of\nthe specified object matches some installed volume populator or dynamic\nprovisioner.\nThis field will replace the functionality of the dataSource field and as such\nif both fields are non-empty, they must have the same value. For backwards\ncompatibility, when namespace isn't specified in dataSourceRef,\nboth fields (dataSource and dataSourceRef) will be set to the same\nvalue automatically if one of them is empty and the other is non-empty.\nWhen namespace is specified in dataSourceRef,\ndataSource isn't set to the same value and must be empty.\nThere are three important differences between dataSource and dataSourceRef:\n* While dataSource only allows two specific types of objects, dataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While dataSource ignores disallowed values (dropping them), dataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n* While dataSource only allows local objects, dataSourceRef allows objects\n  in any namespaces.\n(Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.\n(Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                                            "properties": {
+                                              "apiGroup": {
+                                                "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "description": "Kind is the type of resource being referenced",
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "description": "Name is the name of resource being referenced",
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "description": "Namespace is the namespace of resource being referenced\nNote that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.\n(Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "kind",
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "resources": {
+                                            "description": "resources represents the minimum resources the volume should have.\nIf RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+                                            "properties": {
+                                              "limits": {
+                                                "additionalProperties": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "integer"
+                                                    },
+                                                    {
+                                                      "type": "string"
+                                                    }
+                                                  ],
+                                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                                "type": "object"
+                                              },
+                                              "requests": {
+                                                "additionalProperties": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "integer"
+                                                    },
+                                                    {
+                                                      "type": "string"
+                                                    }
+                                                  ],
+                                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "selector": {
+                                            "description": "selector is a label query over volumes to consider for binding.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "items": {
+                                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "key is the label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "storageClassName": {
+                                            "description": "storageClassName is the name of the StorageClass required by the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+                                            "type": "string"
+                                          },
+                                          "volumeAttributesClassName": {
+                                            "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string or nil value indicates that no\nVolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,\nthis field can be reset to its previous value (including nil) to cancel the modification.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/",
+                                            "type": "string"
+                                          },
+                                          "volumeMode": {
+                                            "description": "volumeMode defines what type of volume is required by the claim.\nValue of Filesystem is implied when not included in claim spec.",
+                                            "type": "string"
+                                          },
+                                          "volumeName": {
+                                            "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "required": [
+                                      "spec"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "fc": {
+                                "description": "fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
+                                "properties": {
+                                  "fsType": {
+                                    "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                    "type": "string"
+                                  },
+                                  "lun": {
+                                    "description": "lun is Optional: FC target lun number",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "readOnly": {
+                                    "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                                    "type": "boolean"
+                                  },
+                                  "targetWWNs": {
+                                    "description": "targetWWNs is Optional: FC target worldwide names (WWNs)",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "wwids": {
+                                    "description": "wwids Optional: FC volume world wide identifiers (wwids)\nEither wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "flexVolume": {
+                                "description": "flexVolume represents a generic volume resource that is\nprovisioned/attached using an exec based plugin.\nDeprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.",
+                                "properties": {
+                                  "driver": {
+                                    "description": "driver is the name of the driver to use for this volume.",
+                                    "type": "string"
+                                  },
+                                  "fsType": {
+                                    "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+                                    "type": "string"
+                                  },
+                                  "options": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "options is Optional: this field holds extra command options if any.",
+                                    "type": "object"
+                                  },
+                                  "readOnly": {
+                                    "description": "readOnly is Optional: defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "description": "secretRef is Optional: secretRef is reference to the secret object containing\nsensitive information to pass to the plugin scripts. This may be\nempty if no secret object is specified. If the secret object\ncontains more than one secret, all secrets are passed to the plugin\nscripts.",
+                                    "properties": {
+                                      "name": {
+                                        "default": "",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "driver"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "flocker": {
+                                "description": "flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.\nDeprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.",
+                                "properties": {
+                                  "datasetName": {
+                                    "description": "datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker\nshould be considered as deprecated",
+                                    "type": "string"
+                                  },
+                                  "datasetUUID": {
+                                    "description": "datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "gcePersistentDisk": {
+                                "description": "gcePersistentDisk represents a GCE Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nDeprecated: GCEPersistentDisk is deprecated. All operations for the in-tree\ngcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                                "properties": {
+                                  "fsType": {
+                                    "description": "fsType is filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                                    "type": "string"
+                                  },
+                                  "partition": {
+                                    "description": "partition is the partition in the volume that you want to mount.\nIf omitted, the default is to mount by volume name.\nExamples: For volume /dev/sda1, you specify the partition as \"1\".\nSimilarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "pdName": {
+                                    "description": "pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "pdName"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "gitRepo": {
+                                "description": "gitRepo represents a git repository at a particular revision.\nDeprecated: GitRepo is deprecated. To provision a container with a git repo, mount an\nEmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir\ninto the Pod's container.",
+                                "properties": {
+                                  "directory": {
+                                    "description": "directory is the target directory name.\nMust not contain or start with '..'.  If '.' is supplied, the volume directory will be the\ngit repository.  Otherwise, if specified, the volume will contain the git repository in\nthe subdirectory with the given name.",
+                                    "type": "string"
+                                  },
+                                  "repository": {
+                                    "description": "repository is the URL",
+                                    "type": "string"
+                                  },
+                                  "revision": {
+                                    "description": "revision is the commit hash for the specified revision.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "repository"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "glusterfs": {
+                                "description": "glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.\nDeprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.",
+                                "properties": {
+                                  "endpoints": {
+                                    "description": "endpoints is the endpoint name that details Glusterfs topology.",
+                                    "type": "string"
+                                  },
+                                  "path": {
+                                    "description": "path is the Glusterfs volume path.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "description": "readOnly here will force the Glusterfs volume to be mounted with read-only permissions.\nDefaults to false.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "endpoints",
+                                  "path"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "hostPath": {
+                                "description": "hostPath represents a pre-existing file or directory on the host\nmachine that is directly exposed to the container. This is generally\nused for system agents or other privileged things that are allowed\nto see the host machine. Most containers will NOT need this.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                                "properties": {
+                                  "path": {
+                                    "description": "path of the directory on the host.\nIf the path is a symlink, it will follow the link to the real path.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "description": "type for HostPath Volume\nDefaults to \"\"\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "path"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "image": {
+                                "description": "image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.\nThe volume is resolved at pod startup depending on which PullPolicy value is provided:\n\n- Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\n- Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\n- IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\n\nThe volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.\nA failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.\nThe types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.\nThe OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.\nThe volume will be mounted read-only (ro) and non-executable files (noexec).\nSub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.\nThe field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.",
+                                "properties": {
+                                  "pullPolicy": {
+                                    "description": "Policy for pulling OCI objects. Possible values are:\nAlways: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\nNever: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\nIfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.",
+                                    "type": "string"
+                                  },
+                                  "reference": {
+                                    "description": "Required: Image or artifact reference to be used.\nBehaves in the same way as pod.spec.containers[*].image.\nPull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "iscsi": {
+                                "description": "iscsi represents an ISCSI Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi",
+                                "properties": {
+                                  "chapAuthDiscovery": {
+                                    "description": "chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication",
+                                    "type": "boolean"
+                                  },
+                                  "chapAuthSession": {
+                                    "description": "chapAuthSession defines whether support iSCSI Session CHAP authentication",
+                                    "type": "boolean"
+                                  },
+                                  "fsType": {
+                                    "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
+                                    "type": "string"
+                                  },
+                                  "initiatorName": {
+                                    "description": "initiatorName is the custom iSCSI Initiator Name.\nIf initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface\n<target portal>:<volume name> will be created for the connection.",
+                                    "type": "string"
+                                  },
+                                  "iqn": {
+                                    "description": "iqn is the target iSCSI Qualified Name.",
+                                    "type": "string"
+                                  },
+                                  "iscsiInterface": {
+                                    "default": "default",
+                                    "description": "iscsiInterface is the interface Name that uses an iSCSI transport.\nDefaults to 'default' (tcp).",
+                                    "type": "string"
+                                  },
+                                  "lun": {
+                                    "description": "lun represents iSCSI Target Lun number.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "portals": {
+                                    "description": "portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port\nis other than default (typically TCP ports 860 and 3260).",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "readOnly": {
+                                    "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.",
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "description": "secretRef is the CHAP Secret for iSCSI target and initiator authentication",
+                                    "properties": {
+                                      "name": {
+                                        "default": "",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "targetPortal": {
+                                    "description": "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port\nis other than default (typically TCP ports 860 and 3260).",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "iqn",
+                                  "lun",
+                                  "targetPortal"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "name": {
+                                "description": "name of the volume.\nMust be a DNS_LABEL and unique within the pod.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              },
+                              "nfs": {
+                                "description": "nfs represents an NFS mount on the host that shares a pod's lifetime\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                                "properties": {
+                                  "path": {
+                                    "description": "path that is exported by the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "description": "readOnly here will force the NFS export to be mounted with read-only permissions.\nDefaults to false.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                                    "type": "boolean"
+                                  },
+                                  "server": {
+                                    "description": "server is the hostname or IP address of the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "path",
+                                  "server"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "persistentVolumeClaim": {
+                                "description": "persistentVolumeClaimVolumeSource represents a reference to a\nPersistentVolumeClaim in the same namespace.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                                "properties": {
+                                  "claimName": {
+                                    "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "description": "readOnly Will force the ReadOnly setting in VolumeMounts.\nDefault false.",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "claimName"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "photonPersistentDisk": {
+                                "description": "photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.\nDeprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.",
+                                "properties": {
+                                  "fsType": {
+                                    "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                    "type": "string"
+                                  },
+                                  "pdID": {
+                                    "description": "pdID is the ID that identifies Photon Controller persistent disk",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "pdID"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "portworxVolume": {
+                                "description": "portworxVolume represents a portworx volume attached and mounted on kubelets host machine.\nDeprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type\nare redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate\nis on.",
+                                "properties": {
+                                  "fsType": {
+                                    "description": "fSType represents the filesystem type to mount\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                                    "type": "boolean"
+                                  },
+                                  "volumeID": {
+                                    "description": "volumeID uniquely identifies a Portworx volume",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "volumeID"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "projected": {
+                                "description": "projected items for all in one resources secrets, configmaps, and downward API",
+                                "properties": {
+                                  "defaultMode": {
+                                    "description": "defaultMode are the mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "sources": {
+                                    "description": "sources is the list of volume projections. Each entry in this list\nhandles one source.",
+                                    "items": {
+                                      "description": "Projection that may be projected along with other supported volume types.\nExactly one of these fields must be set.",
+                                      "properties": {
+                                        "clusterTrustBundle": {
+                                          "description": "ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field\nof ClusterTrustBundle objects in an auto-updating file.\n\nAlpha, gated by the ClusterTrustBundleProjection feature gate.\n\nClusterTrustBundle objects can either be selected by name, or by the\ncombination of signer name and a label selector.\n\nKubelet performs aggressive normalization of the PEM contents written\ninto the pod filesystem.  Esoteric PEM features such as inter-block\ncomments and block headers are stripped.  Certificates are deduplicated.\nThe ordering of certificates within the file is arbitrary, and Kubelet\nmay change the order over time.",
+                                          "properties": {
+                                            "labelSelector": {
+                                              "description": "Select all ClusterTrustBundles that match this label selector.  Only has\neffect if signerName is set.  Mutually-exclusive with name.  If unset,\ninterpreted as \"match nothing\".  If set but empty, interpreted as \"match\neverything\".",
+                                              "properties": {
+                                                "matchExpressions": {
+                                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                  "items": {
+                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                                    "properties": {
+                                                      "key": {
+                                                        "description": "key is the label key that the selector applies to.",
+                                                        "type": "string"
+                                                      },
+                                                      "operator": {
+                                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                        "type": "string"
+                                                      },
+                                                      "values": {
+                                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key",
+                                                      "operator"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
+                                                },
+                                                "matchLabels": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                  "type": "object"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic",
+                                              "additionalProperties": false
+                                            },
+                                            "name": {
+                                              "description": "Select a single ClusterTrustBundle by object name.  Mutually-exclusive\nwith signerName and labelSelector.",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "description": "If true, don't block pod startup if the referenced ClusterTrustBundle(s)\naren't available.  If using name, then the named ClusterTrustBundle is\nallowed not to exist.  If using signerName, then the combination of\nsignerName and labelSelector is allowed to match zero\nClusterTrustBundles.",
+                                              "type": "boolean"
+                                            },
+                                            "path": {
+                                              "description": "Relative path from the volume root to write the bundle.",
+                                              "type": "string"
+                                            },
+                                            "signerName": {
+                                              "description": "Select all ClusterTrustBundles that match this signer name.\nMutually-exclusive with name.  The contents of all selected\nClusterTrustBundles will be unified and deduplicated.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "path"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "configMap": {
+                                          "description": "configMap information about the configMap data to project",
+                                          "properties": {
+                                            "items": {
+                                              "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                                              "items": {
+                                                "description": "Maps a string key to a path within a volume.",
+                                                "properties": {
+                                                  "key": {
+                                                    "description": "key is the key to project.",
+                                                    "type": "string"
+                                                  },
+                                                  "mode": {
+                                                    "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                                    "format": "int32",
+                                                    "type": "integer"
+                                                  },
+                                                  "path": {
+                                                    "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key",
+                                                  "path"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array",
+                                              "x-kubernetes-list-type": "atomic"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "description": "optional specify whether the ConfigMap or its keys must be defined",
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "downwardAPI": {
+                                          "description": "downwardAPI information about the downwardAPI data to project",
+                                          "properties": {
+                                            "items": {
+                                              "description": "Items is a list of DownwardAPIVolume file",
+                                              "items": {
+                                                "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                                "properties": {
+                                                  "fieldRef": {
+                                                    "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
+                                                    "properties": {
+                                                      "apiVersion": {
+                                                        "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                        "type": "string"
+                                                      },
+                                                      "fieldPath": {
+                                                        "description": "Path of the field to select in the specified API version.",
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "fieldPath"
+                                                    ],
+                                                    "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "mode": {
+                                                    "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                                    "format": "int32",
+                                                    "type": "integer"
+                                                  },
+                                                  "path": {
+                                                    "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                                    "type": "string"
+                                                  },
+                                                  "resourceFieldRef": {
+                                                    "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                                    "properties": {
+                                                      "containerName": {
+                                                        "description": "Container name: required for volumes, optional for env vars",
+                                                        "type": "string"
+                                                      },
+                                                      "divisor": {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "integer"
+                                                          },
+                                                          {
+                                                            "type": "string"
+                                                          }
+                                                        ],
+                                                        "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                        "x-kubernetes-int-or-string": true
+                                                      },
+                                                      "resource": {
+                                                        "description": "Required: resource to select",
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "resource"
+                                                    ],
+                                                    "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "required": [
+                                                  "path"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array",
+                                              "x-kubernetes-list-type": "atomic"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "podCertificate": {
+                                          "description": "Projects an auto-rotating credential bundle (private key and certificate\nchain) that the pod can use either as a TLS client or server.\n\nKubelet generates a private key and uses it to send a\nPodCertificateRequest to the named signer.  Once the signer approves the\nrequest and issues a certificate chain, Kubelet writes the key and\ncertificate chain to the pod filesystem.  The pod does not start until\ncertificates have been issued for each podCertificate projected volume\nsource in its spec.\n\nKubelet will begin trying to rotate the certificate at the time indicated\nby the signer using the PodCertificateRequest.Status.BeginRefreshAt\ntimestamp.\n\nKubelet can write a single file, indicated by the credentialBundlePath\nfield, or separate files, indicated by the keyPath and\ncertificateChainPath fields.\n\nThe credential bundle is a single file in PEM format.  The first PEM\nentry is the private key (in PKCS#8 format), and the remaining PEM\nentries are the certificate chain issued by the signer (typically,\nsigners will return their certificate chain in leaf-to-root order).\n\nPrefer using the credential bundle format, since your application code\ncan read it atomically.  If you use keyPath and certificateChainPath,\nyour application must make two separate file reads. If these coincide\nwith a certificate rotation, it is possible that the private key and leaf\ncertificate you read may not correspond to each other.  Your application\nwill need to check for this condition, and re-read until they are\nconsistent.\n\nThe named signer controls chooses the format of the certificate it\nissues; consult the signer implementation's documentation to learn how to\nuse the certificates it issues.",
+                                          "properties": {
+                                            "certificateChainPath": {
+                                              "description": "Write the certificate chain at this path in the projected volume.\n\nMost applications should use credentialBundlePath.  When using keyPath\nand certificateChainPath, your application needs to check that the key\nand leaf certificate are consistent, because it is possible to read the\nfiles mid-rotation.",
+                                              "type": "string"
+                                            },
+                                            "credentialBundlePath": {
+                                              "description": "Write the credential bundle at this path in the projected volume.\n\nThe credential bundle is a single file that contains multiple PEM blocks.\nThe first PEM block is a PRIVATE KEY block, containing a PKCS#8 private\nkey.\n\nThe remaining blocks are CERTIFICATE blocks, containing the issued\ncertificate chain from the signer (leaf and any intermediates).\n\nUsing credentialBundlePath lets your Pod's application code make a single\natomic read that retrieves a consistent key and certificate chain.  If you\nproject them to separate files, your application code will need to\nadditionally check that the leaf certificate was issued to the key.",
+                                              "type": "string"
+                                            },
+                                            "keyPath": {
+                                              "description": "Write the key at this path in the projected volume.\n\nMost applications should use credentialBundlePath.  When using keyPath\nand certificateChainPath, your application needs to check that the key\nand leaf certificate are consistent, because it is possible to read the\nfiles mid-rotation.",
+                                              "type": "string"
+                                            },
+                                            "keyType": {
+                                              "description": "The type of keypair Kubelet will generate for the pod.\n\nValid values are \"RSA3072\", \"RSA4096\", \"ECDSAP256\", \"ECDSAP384\",\n\"ECDSAP521\", and \"ED25519\".",
+                                              "type": "string"
+                                            },
+                                            "maxExpirationSeconds": {
+                                              "description": "maxExpirationSeconds is the maximum lifetime permitted for the\ncertificate.\n\nKubelet copies this value verbatim into the PodCertificateRequests it\ngenerates for this projection.\n\nIf omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver\nwill reject values shorter than 3600 (1 hour).  The maximum allowable\nvalue is 7862400 (91 days).\n\nThe signer implementation is then free to issue a certificate with any\nlifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600\nseconds (1 hour).  This constraint is enforced by kube-apiserver.\n`kubernetes.io` signers will never issue certificates with a lifetime\nlonger than 24 hours.",
+                                              "format": "int32",
+                                              "type": "integer"
+                                            },
+                                            "signerName": {
+                                              "description": "Kubelet's generated CSRs will be addressed to this signer.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "keyType",
+                                            "signerName"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "secret": {
+                                          "description": "secret information about the secret data to project",
+                                          "properties": {
+                                            "items": {
+                                              "description": "items if unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                                              "items": {
+                                                "description": "Maps a string key to a path within a volume.",
+                                                "properties": {
+                                                  "key": {
+                                                    "description": "key is the key to project.",
+                                                    "type": "string"
+                                                  },
+                                                  "mode": {
+                                                    "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                                    "format": "int32",
+                                                    "type": "integer"
+                                                  },
+                                                  "path": {
+                                                    "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key",
+                                                  "path"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array",
+                                              "x-kubernetes-list-type": "atomic"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "description": "optional field specify whether the Secret or its key must be defined",
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "serviceAccountToken": {
+                                          "description": "serviceAccountToken is information about the serviceAccountToken data to project",
+                                          "properties": {
+                                            "audience": {
+                                              "description": "audience is the intended audience of the token. A recipient of a token\nmust identify itself with an identifier specified in the audience of the\ntoken, and otherwise should reject the token. The audience defaults to the\nidentifier of the apiserver.",
+                                              "type": "string"
+                                            },
+                                            "expirationSeconds": {
+                                              "description": "expirationSeconds is the requested duration of validity of the service\naccount token. As the token approaches expiration, the kubelet volume\nplugin will proactively rotate the service account token. The kubelet will\nstart trying to rotate the token if the token is older than 80 percent of\nits time to live or if the token is older than 24 hours.Defaults to 1 hour\nand must be at least 10 minutes.",
+                                              "format": "int64",
+                                              "type": "integer"
+                                            },
+                                            "path": {
+                                              "description": "path is the path relative to the mount point of the file to project the\ntoken into.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "path"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "quobyte": {
+                                "description": "quobyte represents a Quobyte mount on the host that shares a pod's lifetime.\nDeprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.",
+                                "properties": {
+                                  "group": {
+                                    "description": "group to map volume access to\nDefault is no group",
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "description": "readOnly here will force the Quobyte volume to be mounted with read-only permissions.\nDefaults to false.",
+                                    "type": "boolean"
+                                  },
+                                  "registry": {
+                                    "description": "registry represents a single or multiple Quobyte Registry services\nspecified as a string as host:port pair (multiple entries are separated with commas)\nwhich acts as the central registry for volumes",
+                                    "type": "string"
+                                  },
+                                  "tenant": {
+                                    "description": "tenant owning the given Quobyte volume in the Backend\nUsed with dynamically provisioned Quobyte volumes, value is set by the plugin",
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "description": "user to map volume access to\nDefaults to serivceaccount user",
+                                    "type": "string"
+                                  },
+                                  "volume": {
+                                    "description": "volume is a string that references an already created Quobyte volume by name.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "registry",
+                                  "volume"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "rbd": {
+                                "description": "rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.\nDeprecated: RBD is deprecated and the in-tree rbd type is no longer supported.",
+                                "properties": {
+                                  "fsType": {
+                                    "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
+                                    "type": "string"
+                                  },
+                                  "image": {
+                                    "description": "image is the rados image name.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                    "type": "string"
+                                  },
+                                  "keyring": {
+                                    "default": "/etc/ceph/keyring",
+                                    "description": "keyring is the path to key ring for RBDUser.\nDefault is /etc/ceph/keyring.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                    "type": "string"
+                                  },
+                                  "monitors": {
+                                    "description": "monitors is a collection of Ceph monitors.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "pool": {
+                                    "default": "rbd",
+                                    "description": "pool is the rados pool name.\nDefault is rbd.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "description": "secretRef is name of the authentication secret for RBDUser. If provided\noverrides keyring.\nDefault is nil.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                    "properties": {
+                                      "name": {
+                                        "default": "",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "user": {
+                                    "default": "admin",
+                                    "description": "user is the rados user name.\nDefault is admin.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "image",
+                                  "monitors"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "scaleIO": {
+                                "description": "scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.\nDeprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.",
+                                "properties": {
+                                  "fsType": {
+                                    "default": "xfs",
+                                    "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\".\nDefault is \"xfs\".",
+                                    "type": "string"
+                                  },
+                                  "gateway": {
+                                    "description": "gateway is the host address of the ScaleIO API Gateway.",
+                                    "type": "string"
+                                  },
+                                  "protectionDomain": {
+                                    "description": "protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.",
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "description": "readOnly Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "description": "secretRef references to the secret for ScaleIO user and other\nsensitive information. If this is not provided, Login operation will fail.",
+                                    "properties": {
+                                      "name": {
+                                        "default": "",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "sslEnabled": {
+                                    "description": "sslEnabled Flag enable/disable SSL communication with Gateway, default false",
+                                    "type": "boolean"
+                                  },
+                                  "storageMode": {
+                                    "default": "ThinProvisioned",
+                                    "description": "storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.\nDefault is ThinProvisioned.",
+                                    "type": "string"
+                                  },
+                                  "storagePool": {
+                                    "description": "storagePool is the ScaleIO Storage Pool associated with the protection domain.",
+                                    "type": "string"
+                                  },
+                                  "system": {
+                                    "description": "system is the name of the storage system as configured in ScaleIO.",
+                                    "type": "string"
+                                  },
+                                  "volumeName": {
+                                    "description": "volumeName is the name of a volume already created in the ScaleIO system\nthat is associated with this volume source.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "gateway",
+                                  "secretRef",
+                                  "system"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "secret": {
+                                "description": "secret represents a secret that should populate this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                                "properties": {
+                                  "defaultMode": {
+                                    "description": "defaultMode is Optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values\nfor mode bits. Defaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "items": {
+                                    "description": "items If unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                                    "items": {
+                                      "description": "Maps a string key to a path within a volume.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the key to project.",
+                                          "type": "string"
+                                        },
+                                        "mode": {
+                                          "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                          "format": "int32",
+                                          "type": "integer"
+                                        },
+                                        "path": {
+                                          "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "path"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "optional": {
+                                    "description": "optional field specify whether the Secret or its keys must be defined",
+                                    "type": "boolean"
+                                  },
+                                  "secretName": {
+                                    "description": "secretName is the name of the secret in the pod's namespace to use.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "storageos": {
+                                "description": "storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.\nDeprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.",
+                                "properties": {
+                                  "fsType": {
+                                    "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "description": "secretRef specifies the secret to use for obtaining the StorageOS API\ncredentials.  If not specified, default values will be attempted.",
+                                    "properties": {
+                                      "name": {
+                                        "default": "",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "volumeName": {
+                                    "description": "volumeName is the human-readable name of the StorageOS volume.  Volume\nnames are only unique within a namespace.",
+                                    "type": "string"
+                                  },
+                                  "volumeNamespace": {
+                                    "description": "volumeNamespace specifies the scope of the volume within StorageOS.  If no\nnamespace is specified then the Pod's namespace will be used.  This allows the\nKubernetes name scoping to be mirrored within StorageOS for tighter integration.\nSet VolumeName to any name to override the default behaviour.\nSet to \"default\" if you are not using namespaces within StorageOS.\nNamespaces that do not pre-exist within StorageOS will be created.",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "vsphereVolume": {
+                                "description": "vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.\nDeprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type\nare redirected to the csi.vsphere.vmware.com CSI driver.",
+                                "properties": {
+                                  "fsType": {
+                                    "description": "fsType is filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                    "type": "string"
+                                  },
+                                  "storagePolicyID": {
+                                    "description": "storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+                                    "type": "string"
+                                  },
+                                  "storagePolicyName": {
+                                    "description": "storagePolicyName is the storage Policy Based Management (SPBM) profile name.",
+                                    "type": "string"
+                                  },
+                                  "volumePath": {
+                                    "description": "volumePath is the path that identifies vSphere volume vmdk",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "volumePath"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-map-keys": [
+                            "name"
+                          ],
+                          "x-kubernetes-list-type": "map"
+                        }
+                      },
+                      "required": [
+                        "containers"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "ttlSecondsAfterFinished": {
+                  "description": "ttlSecondsAfterFinished limits the lifetime of a Job that has finished\nexecution (either Complete or Failed). If this field is set,\nttlSecondsAfterFinished after the Job finishes, it is eligible to be\nautomatically deleted. When the Job is being deleted, its lifecycle\nguarantees (e.g. finalizers) will be honored. If this field is unset,\nthe Job won't be automatically deleted. If this field is set to zero,\nthe Job becomes eligible to be deleted immediately after it finishes.",
+                  "format": "int32",
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "template"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "maxReplicaCount": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "minReplicaCount": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "pollingInterval": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "rollout": {
+              "description": "Rollout defines the strategy for job rollouts",
+              "properties": {
+                "propagationPolicy": {
+                  "type": "string"
+                },
+                "strategy": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "scalingStrategy": {
+              "description": "ScalingStrategy defines the strategy of Scaling",
+              "properties": {
+                "customScalingQueueLengthDeduction": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "customScalingRunningJobPercentage": {
+                  "type": "string"
+                },
+                "multipleScalersCalculation": {
+                  "type": "string"
+                },
+                "pendingPodConditions": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "strategy": {
+                  "enum": [
+                    "basic",
+                    "custom",
+                    "accurate",
+                    "eager",
+                    "pendingAware"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "successfulJobsHistoryLimit": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "triggers": {
+              "items": {
+                "description": "ScaleTriggers reference the scaler that will be used",
+                "properties": {
+                  "authenticationRef": {
+                    "description": "AuthenticationRef points to the TriggerAuthentication or ClusterTriggerAuthentication object that\nis used to authenticate the scaler with the environment",
+                    "properties": {
+                      "kind": {
+                        "description": "Kind of the resource being referred to. Defaults to TriggerAuthentication.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "metadata": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  },
+                  "metricType": {
+                    "description": "MetricTargetType specifies the type of metric being targeted, and should be either\n\"Value\", \"AverageValue\", or \"Utilization\"",
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "useCachedMetrics": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "metadata",
+                  "type"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "maxItems": 64,
+              "type": "array",
+              "x-kubernetes-validations": [
+                {
+                  "message": "triggers.name must be non-empty",
+                  "rule": "self.all(t, t.name != '')"
+                },
+                {
+                  "message": "triggers.name values must be unique",
+                  "rule": "self.map(t, t.name).all(n, self.map(t, t.name).filter(x, x == n).size() == 1)"
+                }
+              ]
+            }
+          },
+          "required": [
+            "jobTargetRef",
+            "triggers"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "totalTargetReplicas": {
+          "default": 0,
+          "description": "TotalTargetReplicas is the desired number of replicas",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "scaledJobSpec"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "memberClusters must be non-empty when clusterScheduling.strategy=priorityFailover",
+          "rule": "self.clusterScheduling.strategy != 'priorityFailover' || (has(self.memberClusters) && self.memberClusters.size() > 0)"
+        },
+        {
+          "message": "memberClusters[].scheduling.priority is required when clusterScheduling.strategy=priorityFailover",
+          "rule": "self.clusterScheduling.strategy != 'priorityFailover' || (has(self.memberClusters) && self.memberClusters.all(c, has(c.scheduling) && has(c.scheduling.priority)))"
+        },
+        {
+          "message": "scaledJobSpec.scalingStrategy.strategy must be pendingAware (or omitted) when clusterScheduling.strategy=priorityFailover",
+          "rule": "self.clusterScheduling.strategy != 'priorityFailover' || self.scaledJobSpec.scalingStrategy.strategy == '' || self.scaledJobSpec.scalingStrategy.strategy == 'pendingAware'"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "DistributedScaledJobStatus defines the observed state of DistributedScaledJob",
+      "properties": {
+        "conditions": {
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "desiredJobs": {
+          "description": "DesiredJobs is the desired number of jobs calculated from metrics",
+          "format": "int64",
+          "type": "integer"
+        },
+        "memberClusterStatuses": {
+          "additionalProperties": {
+            "description": "DistributedScaledJobMemberClusterStatus represents the status of a member cluster",
+            "properties": {
+              "description": {
+                "description": "Description provides additional information about the member cluster status",
+                "type": "string"
+              },
+              "excluded": {
+                "description": "Excluded indicates whether the member cluster is excluded from scaling\nfor example, due to being unhealthy for longer than the grace period",
+                "type": "boolean"
+              },
+              "hardTaintScopes": {
+                "description": "HardTaintScopes lists hard-taint scopes for priorityFailover scheduling.\nMultiple entries may exist for a single cluster (for different classes/priorities).",
+                "items": {
+                  "description": "DistributedScaledJobHardTaintScope identifies one priorityFailover hard-taint scope.",
+                  "properties": {
+                    "class": {
+                      "description": "Class is the workload affinity class for which the cluster is tainted.\nThis can be empty to represent the default affinity class.",
+                      "type": "string"
+                    },
+                    "priority": {
+                      "description": "Priority is the member-cluster scheduling priority for which the cluster is tainted.",
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "class"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "hardTainted": {
+                "description": "HardTainted indicates the cluster is hard tainted for at least one DSJ scheduling path.",
+                "type": "boolean"
+              },
+              "id": {
+                "description": "ID is the identification of the member cluster for multicluster-controller",
+                "type": "string"
+              },
+              "lastScalingProgressTime": {
+                "description": "LastScalingProgressTime is the last time the scaling made progress\nThis is used to determine how long the member cluster has been making slow progress for rebalancing purposes",
+                "format": "date-time",
+                "type": "string"
+              },
+              "lastStatusChangeTime": {
+                "description": "LastStatusChangeTime is the last time the status changed\nThis is used to determine how long the member cluster has been unhealthy for rebalancing purposes",
+                "format": "date-time",
+                "type": "string"
+              },
+              "pendingJobs": {
+                "description": "PendingJobs is the number of jobs that are pending in the member cluster",
+                "format": "int32",
+                "type": "integer"
+              },
+              "runningJobs": {
+                "description": "RunningJobs is the current number of running jobs in the member cluster",
+                "format": "int32",
+                "type": "integer"
+              },
+              "softTainted": {
+                "description": "SoftTainted indicates the cluster has a recent failure but is not hard tainted",
+                "type": "boolean"
+              },
+              "state": {
+                "description": "State is the state of the member cluster (e.g., Ready, NotReady)",
+                "type": "string"
+              },
+              "stuckJobs": {
+                "description": "StuckJobs is the number of jobs that are stuck (e.g., pending for too long) in the member cluster",
+                "format": "int32",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "description",
+              "id",
+              "pendingJobs",
+              "runningJobs",
+              "state",
+              "stuckJobs"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "MemberClusterStatuses represents the status of each member cluster",
+          "type": "object"
+        },
+        "pendingJobs": {
+          "description": "PendingJobs is the current number of pending jobs across all member clusters",
+          "format": "int64",
+          "type": "integer"
+        },
+        "print": {
+          "description": "Print is used for custom printing of DistributedScaledJob status",
+          "properties": {
+            "membersCount": {
+              "description": "MembersCount is the status of member clusters",
+              "type": "string"
+            },
+            "runningJobs": {
+              "description": "RunningJobs represents the status of running jobs across member clusters",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "runningJobs": {
+          "description": "RunningJobs is the current number of running jobs across all member clusters",
+          "format": "int64",
+          "type": "integer"
+        },
+        "scalersTargetAverageValue": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "ScalersTargetAverageValue is the target average value across all scalers",
+          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+          "x-kubernetes-int-or-string": true
+        },
+        "selector": {
+          "description": "Selector is the selector for the distributed jobs",
+          "type": "string"
+        },
+        "triggerMetricsStatus": {
+          "additionalProperties": {
+            "description": "TriggerMetricStatus represents the status of a single metric used for scaling by trigger name",
+            "properties": {
+              "info": {
+                "description": "Info provides additional information about the metric status, such as error messages or reasons for inactivity",
+                "type": "string"
+              },
+              "lastChangeTime": {
+                "description": "LastChangeTime is the last time the metric status changed, used for tracking how long a metric has been in a particular state",
+                "format": "date-time",
+                "type": "string"
+              },
+              "state": {
+                "description": "State represents the state of the metric (\"Active\", \"Inactive\", \"Error\") used to determine if scaling should occur",
+                "type": "string"
+              }
+            },
+            "required": [
+              "state"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "TriggerMetricStatus represents the status of each metric used for scaling by trigger name",
+          "type": "object"
+        }
+      },
+      "required": [
+        "desiredJobs",
+        "pendingJobs",
+        "runningJobs",
+        "selector"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/crd-schemas/distributedscaledobject_v1alpha1.json
+++ b/crd-schemas/distributedscaledobject_v1alpha1.json
@@ -1,0 +1,550 @@
+{
+  "description": "DistributedScaledObject is the Schema for the DistributedScaledObject API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DistributedScaledObjectSpec defines the desired state of DistributedScaledObject",
+      "properties": {
+        "memberClusters": {
+          "description": "MemberClusters is the list of member clusters where the ScaledObject should trigger scaling of the target workloads\nif empty, use all available member clusters",
+          "items": {
+            "description": "DistributedScaledObjectMemberCluster represents a member cluster where the DistributedScaledObject should be applied.",
+            "properties": {
+              "name": {
+                "description": "Name is the name of the member cluster.",
+                "type": "string"
+              },
+              "targetNamespace": {
+                "description": "TargetNamespace is the namespace in the member cluster where the scaling should be applied.\nDefaults to the namespace of the owning distributed resource if not specified.",
+                "type": "string"
+              },
+              "weight": {
+                "default": 1,
+                "description": "Weight is the weight of the member cluster for scaling distribution.",
+                "format": "int32",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "name",
+              "weight"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "rebalancingPolicy": {
+          "default": {
+            "gracePeriod": "1m",
+            "maxRebalancePercentage": 50
+          },
+          "description": "RebalancingPolicy controls how the controller should behave when clusters fail",
+          "properties": {
+            "gracePeriod": {
+              "default": "1m",
+              "description": "FailureGracePeriod is the duration to wait before rebalancing the replicas when a member cluster becomes unhealthy",
+              "type": "string"
+            },
+            "maxRebalancePercentage": {
+              "default": 50,
+              "description": "MaxRebalancePercentage is the maximum percentage of replicas that can be rebalanced at once",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "gracePeriod",
+            "maxRebalancePercentage"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "scaledObjectSpec": {
+          "description": "ScaledObjectSpec is the specification of the KEDA ScaledObject",
+          "properties": {
+            "advanced": {
+              "description": "AdvancedConfig specifies advance scaling options",
+              "properties": {
+                "horizontalPodAutoscalerConfig": {
+                  "description": "HorizontalPodAutoscalerConfig specifies horizontal scale config",
+                  "properties": {
+                    "behavior": {
+                      "description": "HorizontalPodAutoscalerBehavior configures the scaling behavior of the target\nin both Up and Down directions (scaleUp and scaleDown fields respectively).",
+                      "properties": {
+                        "scaleDown": {
+                          "description": "scaleDown is scaling policy for scaling Down.\nIf not set, the default value is to allow to scale down to minReplicas pods, with a\n300 second stabilization window (i.e., the highest recommendation for\nthe last 300sec is used).",
+                          "properties": {
+                            "policies": {
+                              "description": "policies is a list of potential scaling polices which can be used during scaling.\nIf not set, use the default values:\n- For scale up: allow doubling the number of pods, or an absolute change of 4 pods in a 15s window.\n- For scale down: allow all pods to be removed in a 15s window.",
+                              "items": {
+                                "description": "HPAScalingPolicy is a single policy which must hold true for a specified past interval.",
+                                "properties": {
+                                  "periodSeconds": {
+                                    "description": "periodSeconds specifies the window of time for which the policy should hold true.\nPeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "type": {
+                                    "description": "type is used to specify the scaling policy.",
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "value contains the amount of change which is permitted by the policy.\nIt must be greater than zero",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "periodSeconds",
+                                  "type",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "selectPolicy": {
+                              "description": "selectPolicy is used to specify which policy should be used.\nIf not set, the default value Max is used.",
+                              "type": "string"
+                            },
+                            "stabilizationWindowSeconds": {
+                              "description": "stabilizationWindowSeconds is the number of seconds for which past recommendations should be\nconsidered while scaling up or scaling down.\nStabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour).\nIf not set, use the default values:\n- For scale up: 0 (i.e. no stabilization is done).\n- For scale down: 300 (i.e. the stabilization window is 300 seconds long).",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "tolerance": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "description": "tolerance is the tolerance on the ratio between the current and desired\nmetric value under which no updates are made to the desired number of\nreplicas (e.g. 0.01 for 1%). Must be greater than or equal to zero. If not\nset, the default cluster-wide tolerance is applied (by default 10%).\n\nFor example, if autoscaling is configured with a memory consumption target of 100Mi,\nand scale-down and scale-up tolerances of 5% and 1% respectively, scaling will be\ntriggered when the actual consumption falls below 95Mi or exceeds 101Mi.\n\nThis is an alpha field and requires enabling the HPAConfigurableTolerance\nfeature gate.",
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "scaleUp": {
+                          "description": "scaleUp is scaling policy for scaling Up.\nIf not set, the default value is the higher of:\n  * increase no more than 4 pods per 60 seconds\n  * double the number of pods per 60 seconds\nNo stabilization is used.",
+                          "properties": {
+                            "policies": {
+                              "description": "policies is a list of potential scaling polices which can be used during scaling.\nIf not set, use the default values:\n- For scale up: allow doubling the number of pods, or an absolute change of 4 pods in a 15s window.\n- For scale down: allow all pods to be removed in a 15s window.",
+                              "items": {
+                                "description": "HPAScalingPolicy is a single policy which must hold true for a specified past interval.",
+                                "properties": {
+                                  "periodSeconds": {
+                                    "description": "periodSeconds specifies the window of time for which the policy should hold true.\nPeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "type": {
+                                    "description": "type is used to specify the scaling policy.",
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "value contains the amount of change which is permitted by the policy.\nIt must be greater than zero",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "periodSeconds",
+                                  "type",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "selectPolicy": {
+                              "description": "selectPolicy is used to specify which policy should be used.\nIf not set, the default value Max is used.",
+                              "type": "string"
+                            },
+                            "stabilizationWindowSeconds": {
+                              "description": "stabilizationWindowSeconds is the number of seconds for which past recommendations should be\nconsidered while scaling up or scaling down.\nStabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour).\nIf not set, use the default values:\n- For scale up: 0 (i.e. no stabilization is done).\n- For scale down: 300 (i.e. the stabilization window is 300 seconds long).",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "tolerance": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "description": "tolerance is the tolerance on the ratio between the current and desired\nmetric value under which no updates are made to the desired number of\nreplicas (e.g. 0.01 for 1%). Must be greater than or equal to zero. If not\nset, the default cluster-wide tolerance is applied (by default 10%).\n\nFor example, if autoscaling is configured with a memory consumption target of 100Mi,\nand scale-down and scale-up tolerances of 5% and 1% respectively, scaling will be\ntriggered when the actual consumption falls below 95Mi or exceeds 101Mi.\n\nThis is an alpha field and requires enabling the HPAConfigurableTolerance\nfeature gate.",
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "restoreToOriginalReplicaCount": {
+                  "type": "boolean"
+                },
+                "scalingModifiers": {
+                  "description": "ScalingModifiers describes advanced scaling logic options like formula",
+                  "properties": {
+                    "activationTarget": {
+                      "type": "string"
+                    },
+                    "formula": {
+                      "type": "string"
+                    },
+                    "metricType": {
+                      "description": "MetricTargetType specifies the type of metric being targeted, and should be either\n\"Value\", \"AverageValue\", or \"Utilization\"",
+                      "enum": [
+                        "AverageValue",
+                        "Value"
+                      ],
+                      "type": "string"
+                    },
+                    "target": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "cooldownPeriod": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "fallback": {
+              "description": "Fallback is the spec for fallback options",
+              "properties": {
+                "behavior": {
+                  "default": "static",
+                  "enum": [
+                    "static",
+                    "currentReplicas",
+                    "currentReplicasIfHigher",
+                    "currentReplicasIfLower"
+                  ],
+                  "type": "string"
+                },
+                "failureThreshold": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "replicas": {
+                  "format": "int32",
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "failureThreshold",
+                "replicas"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "idleReplicaCount": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "initialCooldownPeriod": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "maxReplicaCount": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "minReplicaCount": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "pollingInterval": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "scaleTargetRef": {
+              "description": "ScaleTarget holds the reference to the scale target Object",
+              "properties": {
+                "apiVersion": {
+                  "type": "string"
+                },
+                "envSourceContainerName": {
+                  "type": "string"
+                },
+                "kind": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "triggers": {
+              "items": {
+                "description": "ScaleTriggers reference the scaler that will be used",
+                "properties": {
+                  "authenticationRef": {
+                    "description": "AuthenticationRef points to the TriggerAuthentication or ClusterTriggerAuthentication object that\nis used to authenticate the scaler with the environment",
+                    "properties": {
+                      "kind": {
+                        "description": "Kind of the resource being referred to. Defaults to TriggerAuthentication.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "metadata": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  },
+                  "metricType": {
+                    "description": "MetricTargetType specifies the type of metric being targeted, and should be either\n\"Value\", \"AverageValue\", or \"Utilization\"",
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "useCachedMetrics": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "metadata",
+                  "type"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "scaleTargetRef",
+            "triggers"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "totalTargetReplicas": {
+          "default": 0,
+          "description": "TotalTargetReplicas is the desired number of replicas",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "rebalancingPolicy",
+        "scaledObjectSpec"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "DistributedScaledObjectStatus defines the observed state of DistributedScaledObject",
+      "properties": {
+        "conditions": {
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "memberClusterStatuses": {
+          "additionalProperties": {
+            "description": "DistributedScaledObjectMemberClusterStatus represents a member cluster status for DistributedScaledObject.",
+            "properties": {
+              "currentReplicas": {
+                "description": "CurrentReplicas is the current number of replicas in the member cluster",
+                "format": "int32",
+                "type": "integer"
+              },
+              "description": {
+                "description": "Description provides additional information about the member cluster status",
+                "type": "string"
+              },
+              "desiredReplicas": {
+                "description": "DesiredReplicas is the desired number of replicas in the member cluster",
+                "format": "int32",
+                "type": "integer"
+              },
+              "excluded": {
+                "description": "Excluded indicates whether the member cluster is excluded from scaling\nfor example, due to being unhealthy for longer than the grace period",
+                "type": "boolean"
+              },
+              "id": {
+                "description": "ID is the identification of the member cluster for multicluster-controller",
+                "type": "string"
+              },
+              "lastScalingProgressTime": {
+                "description": "LastScalingProgressTime is the last time the scaling made progress\nThis is used to determine how long the member cluster has been making slow progress for rebalancing purposes",
+                "format": "date-time",
+                "type": "string"
+              },
+              "lastStatusChangeTime": {
+                "description": "LastStatusChangeTime is the last time the status changed\nThis is used to determine how long the member cluster has been unhealthy for rebalancing purposes",
+                "format": "date-time",
+                "type": "string"
+              },
+              "state": {
+                "description": "State is the state of the member cluster (e.g., Ready, NotReady)",
+                "type": "string"
+              }
+            },
+            "required": [
+              "currentReplicas",
+              "description",
+              "desiredReplicas",
+              "id",
+              "state"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "MemberClusterStatuses represents the status of each member cluster",
+          "type": "object"
+        },
+        "membersHealthyCount": {
+          "description": "MembersHealthyCount is the number of healthy member clusters",
+          "format": "int32",
+          "type": "integer"
+        },
+        "membersTotalCount": {
+          "description": "MembersTotalCount is the total number of member clusters",
+          "format": "int32",
+          "type": "integer"
+        },
+        "print": {
+          "description": "Print is used for custom printing of DistributedScaledObject status",
+          "properties": {
+            "membersCount": {
+              "description": "MembersCountStatus is the status of member clusters",
+              "type": "string"
+            },
+            "totalReplicas": {
+              "description": "TotalReplicas represents the status of replicas across member clusters",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "selector": {
+          "description": "Selector is the selector for HPA",
+          "type": "string"
+        },
+        "totalCurrentReplicas": {
+          "description": "TotalCurrentReplicas is the current number of replicas",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "selector",
+        "totalCurrentReplicas"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/crd-schemas/kedifyconfiguration_v1alpha1.json
+++ b/crd-schemas/kedifyconfiguration_v1alpha1.json
@@ -1,0 +1,415 @@
+{
+  "description": "KedifyConfiguration is the Schema for the KedifyConfiguration API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "KedifyConfigurationSpec defines the desired state of KedifyConfiguration",
+      "properties": {
+        "cloudAccountID": {
+          "description": "CloudAccountID is the optional ID of the cloud account of the user,\nfind your cloud account IDs in the Kedify Dashboard https://dashboard.kedify.io/organization-details",
+          "pattern": "^(aws:|gcp:|kfy:)[a-zA-Z0-9][a-zA-Z0-9-]*$",
+          "type": "string"
+        },
+        "clusterName": {
+          "description": "ClusterName is the name of this k8s cluster in the Kedify Dashboard",
+          "type": "string"
+        },
+        "kedaInstallations": {
+          "description": "KEDAInstallations defines the KEDA installations options",
+          "items": {
+            "description": "KEDAInstallation defines the desired state of a KEDA installation",
+            "properties": {
+              "agentAutoUpdate": {
+                "description": "AutoUpdate controls whether the agent should be auto updated to latest released version",
+                "type": "boolean"
+              },
+              "httpAddonHelm": {
+                "description": "HTTPAddonHelm defines the http-addon Helm values and chart version for HTTP Addon installation",
+                "properties": {
+                  "appVersion": {
+                    "description": "AppVersion defines the actual version of the application that will be installed (KEDA or HttpAddon, this should correspond with the container image tags)",
+                    "type": "string"
+                  },
+                  "autoUpdate": {
+                    "description": "AutoUpdate controls what strategy should be used for updating the AppVersion when new releases are available",
+                    "enum": [
+                      "LatestReleased",
+                      "BuildsOnly",
+                      "PatchesOnly",
+                      "Disabled"
+                    ],
+                    "type": "string"
+                  },
+                  "chartVersion": {
+                    "description": "ChartVersion defines the Helm chart version",
+                    "type": "string"
+                  },
+                  "enabled": {
+                    "description": "Enabled determines whether the helm chart should be installed or not (for KEDA helm chart ManagementMode needs to also allow this)",
+                    "type": "boolean"
+                  },
+                  "values": {
+                    "description": "Values defines the Helm values",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "kedaHelm": {
+                "description": "KedaHelm defines the Helm values and chart version for KEDA installation",
+                "properties": {
+                  "appVersion": {
+                    "description": "AppVersion defines the actual version of the application that will be installed (KEDA or HttpAddon, this should correspond with the container image tags)",
+                    "type": "string"
+                  },
+                  "autoUpdate": {
+                    "description": "AutoUpdate controls what strategy should be used for updating the AppVersion when new releases are available",
+                    "enum": [
+                      "LatestReleased",
+                      "BuildsOnly",
+                      "PatchesOnly",
+                      "Disabled"
+                    ],
+                    "type": "string"
+                  },
+                  "chartVersion": {
+                    "description": "ChartVersion defines the Helm chart version",
+                    "type": "string"
+                  },
+                  "enabled": {
+                    "description": "Enabled determines whether the helm chart should be installed or not (for KEDA helm chart ManagementMode needs to also allow this)",
+                    "type": "boolean"
+                  },
+                  "values": {
+                    "description": "Values defines the Helm values",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "mode": {
+                "description": "Mode defines how Agent should manage the KEDA installation\nManaged: Agent will manage KEDA throughout its lifecycle\nInstallOnly: Agent will install KEDA but not manage it\nAdopt: Agent will adopt an existing KEDA installation",
+                "enum": [
+                  "Managed",
+                  "InstallOnly",
+                  "Adopt",
+                  "Auto",
+                  "Disabled",
+                  "Helm"
+                ],
+                "type": "string"
+              },
+              "name": {
+                "description": "Name of the KEDA installation",
+                "type": "string"
+              },
+              "namespace": {
+                "description": "Namespace where KEDA should be installed",
+                "type": "string"
+              },
+              "otelAddonHelm": {
+                "description": "OTELAddonHelm defines the otel-addon Helm values and chart version for OTEL Addon installation",
+                "properties": {
+                  "appVersion": {
+                    "description": "AppVersion defines the actual version of the application that will be installed (KEDA or HttpAddon, this should correspond with the container image tags)",
+                    "type": "string"
+                  },
+                  "autoUpdate": {
+                    "description": "AutoUpdate controls what strategy should be used for updating the AppVersion when new releases are available",
+                    "enum": [
+                      "LatestReleased",
+                      "BuildsOnly",
+                      "PatchesOnly",
+                      "Disabled"
+                    ],
+                    "type": "string"
+                  },
+                  "chartVersion": {
+                    "description": "ChartVersion defines the Helm chart version",
+                    "type": "string"
+                  },
+                  "enabled": {
+                    "description": "Enabled determines whether the helm chart should be installed or not (for KEDA helm chart ManagementMode needs to also allow this)",
+                    "type": "boolean"
+                  },
+                  "values": {
+                    "description": "Values defines the Helm values",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "predictorAddonHelm": {
+                "description": "PredictorAddonHelm defines the predictor-addon Helm values and chart version for Predictor Addon installation",
+                "properties": {
+                  "appVersion": {
+                    "description": "AppVersion defines the actual version of the application that will be installed (KEDA or HttpAddon, this should correspond with the container image tags)",
+                    "type": "string"
+                  },
+                  "autoUpdate": {
+                    "description": "AutoUpdate controls what strategy should be used for updating the AppVersion when new releases are available",
+                    "enum": [
+                      "LatestReleased",
+                      "BuildsOnly",
+                      "PatchesOnly",
+                      "Disabled"
+                    ],
+                    "type": "string"
+                  },
+                  "chartVersion": {
+                    "description": "ChartVersion defines the Helm chart version",
+                    "type": "string"
+                  },
+                  "enabled": {
+                    "description": "Enabled determines whether the helm chart should be installed or not (for KEDA helm chart ManagementMode needs to also allow this)",
+                    "type": "boolean"
+                  },
+                  "values": {
+                    "description": "Values defines the Helm values",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "telemetry": {
+                "description": "Telemetry defines the telemetry configuration",
+                "properties": {
+                  "controlPlane": {
+                    "description": "ControlPlane defines the telemetry configuration for the control plane",
+                    "properties": {
+                      "disabled": {
+                        "description": "Disabled defines if telemetry should be disabled, enabled by default",
+                        "type": "boolean"
+                      },
+                      "interval": {
+                        "description": "Interval defines the interval for telemetry in seconds, 30 by default",
+                        "format": "int32",
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "kedaResources": {
+                    "description": "KedaResources defines the telemetry configuration for the KEDA resources",
+                    "properties": {
+                      "disabled": {
+                        "description": "Disabled defines if telemetry should be disabled, enabled by default",
+                        "type": "boolean"
+                      },
+                      "interval": {
+                        "description": "Interval defines the interval for telemetry in seconds, 30 by default",
+                        "format": "int32",
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "kubernetesResources": {
+                    "description": "KubernetesResources defines the telemetry configuration for the Kubernetes resources",
+                    "properties": {
+                      "disabled": {
+                        "description": "Disabled defines if telemetry should be disabled, enabled by default",
+                        "type": "boolean"
+                      },
+                      "interval": {
+                        "description": "Interval defines the interval for telemetry in seconds, 30 by default",
+                        "format": "int32",
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "agentAutoUpdate",
+              "mode"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "KedifyConfigurationStatus defines the observed state of KedifyConfiguration",
+      "properties": {
+        "agent": {
+          "description": "Agent contains agent related status information",
+          "properties": {
+            "controlPlaneMetrics": {
+              "type": "string"
+            },
+            "k8sResourcesMetrics": {
+              "type": "string"
+            },
+            "kedaResourcesMetrics": {
+              "type": "string"
+            },
+            "observedHelmValues": {
+              "type": "string"
+            },
+            "phase": {
+              "type": "string"
+            },
+            "reason": {
+              "type": "string"
+            },
+            "uninstallationStartedAt": {
+              "format": "date-time",
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "apiService": {
+          "description": "APIService captures the observed status of API Service registration called v1beta1.external.metrics.k8s.io",
+          "properties": {
+            "phase": {
+              "type": "string"
+            },
+            "reason": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "components": {
+          "additionalProperties": {
+            "description": "KedifyComponentInstallationStatus defines the observed state of a KedifyInstallation",
+            "properties": {
+              "adoptedAt": {
+                "format": "date-time",
+                "type": "string"
+              },
+              "deployments": {
+                "additionalProperties": {
+                  "description": "KedifyConfigurationResourceStatus defines the observed state of a KedifyConfiguration owned resources",
+                  "properties": {
+                    "phase": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "object"
+              },
+              "firstHealthyAt": {
+                "format": "date-time",
+                "type": "string"
+              },
+              "helmReleaseName": {
+                "type": "string"
+              },
+              "observedHelmValues": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "Components captures the observed status of Kedify components (Keda, Http Addon and Otel Addon)",
+          "type": "object"
+        },
+        "configSHA256": {
+          "description": "ConfigSHA256 calculated sha over all relevant field used for internal purposes",
+          "type": "string"
+        },
+        "multiClusterStatus": {
+          "description": "MultiClusterStatus contains status information about multi-cluster deployments",
+          "properties": {
+            "clusters": {
+              "additionalProperties": {
+                "description": "ClusterStatus defines the observed state of a cluster",
+                "properties": {
+                  "hardTaintScopes": {
+                    "description": "HardTaintScopes lists hard-taint scopes for DSJs using priorityFailover.\nMultiple entries may exist for a single cluster (for different classes/priorities).",
+                    "items": {
+                      "description": "ClusterHardTaintScope identifies one priorityFailover hard-taint scope.",
+                      "properties": {
+                        "class": {
+                          "description": "Class is the workload affinity class for which the cluster is tainted.\nThis can be empty to represent the default affinity class.",
+                          "type": "string"
+                        },
+                        "priority": {
+                          "description": "Priority is the member-cluster scheduling priority for which the cluster is tainted.",
+                          "format": "int32",
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "class"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "hardTainted": {
+                    "description": "HardTainted indicates the cluster is hard tainted for at least one DSJ scheduling path.",
+                    "type": "boolean"
+                  },
+                  "id": {
+                    "description": "ID is the unique identifier of the cluster",
+                    "type": "string"
+                  },
+                  "info": {
+                    "description": "Info contains additional information about the cluster status",
+                    "type": "string"
+                  },
+                  "state": {
+                    "description": "State is the current state of the cluster",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/crd-schemas/podresourceautoscaler_v1alpha1.json
+++ b/crd-schemas/podresourceautoscaler_v1alpha1.json
@@ -1,0 +1,785 @@
+{
+  "description": "PodResourceAutoscaler is the Schema for the PodResourceAutoscaler API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "PodResourceAutoscalerSpec defines the desired state of PodResourceAutoscaler",
+      "properties": {
+        "bounds": {
+          "description": "Bounds defines optional bounds and step constraints for request/limit scaling",
+          "properties": {
+            "cpu": {
+              "description": "CPU defines bounds/steps for CPU requests and limits.",
+              "properties": {
+                "limits": {
+                  "description": "Limits defines optional bounds/steps for limits.\nIf omitted, scaling for this side has no extra bounds from this section.",
+                  "properties": {
+                    "max": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "Max defines maximum allowed value for the resource",
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "min": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "Min defines minimum allowed value for the resource",
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "step": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "Step defines maximum absolute change per resize",
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "stepPercent": {
+                      "description": "StepPercent defines maximum percent change per resize (of current value)",
+                      "format": "int32",
+                      "maximum": 100,
+                      "minimum": 1,
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "requests": {
+                  "description": "Requests defines optional bounds/steps for requests.\nIf omitted, scaling for this side has no extra bounds from this section.",
+                  "properties": {
+                    "max": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "Max defines maximum allowed value for the resource",
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "min": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "Min defines minimum allowed value for the resource",
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "step": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "Step defines maximum absolute change per resize",
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "stepPercent": {
+                      "description": "StepPercent defines maximum percent change per resize (of current value)",
+                      "format": "int32",
+                      "maximum": 100,
+                      "minimum": 1,
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "Specify requests and/or limits bounds",
+                  "rule": "has(self.requests) || has(self.limits)"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "memory": {
+              "description": "Memory defines bounds/steps for memory requests and limits.",
+              "properties": {
+                "limits": {
+                  "description": "Limits defines optional bounds/steps for limits.\nIf omitted, scaling for this side has no extra bounds from this section.",
+                  "properties": {
+                    "max": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "Max defines maximum allowed value for the resource",
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "min": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "Min defines minimum allowed value for the resource",
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "step": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "Step defines maximum absolute change per resize",
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "stepPercent": {
+                      "description": "StepPercent defines maximum percent change per resize (of current value)",
+                      "format": "int32",
+                      "maximum": 100,
+                      "minimum": 1,
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "requests": {
+                  "description": "Requests defines optional bounds/steps for requests.\nIf omitted, scaling for this side has no extra bounds from this section.",
+                  "properties": {
+                    "max": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "Max defines maximum allowed value for the resource",
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "min": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "Min defines minimum allowed value for the resource",
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "step": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "Step defines maximum absolute change per resize",
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "stepPercent": {
+                      "description": "StepPercent defines maximum percent change per resize (of current value)",
+                      "format": "int32",
+                      "maximum": 100,
+                      "minimum": 1,
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "Specify requests and/or limits bounds",
+                  "rule": "has(self.requests) || has(self.limits)"
+                }
+              ],
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "containerName": {
+          "description": "ContainerName what container in the pod should be updated",
+          "minLength": 1,
+          "type": "string"
+        },
+        "paused": {
+          "default": false,
+          "description": "Paused if set to true, can make the controller ignore this CR",
+          "type": "boolean"
+        },
+        "policy": {
+          "description": "Policy defines how usage is evaluated and when scaling occurs",
+          "properties": {
+            "after": {
+              "default": "containerReady",
+              "description": "After specifies the pod/container state required before a resize is applied",
+              "enum": [
+                "running",
+                "containerReady",
+                "podReady"
+              ],
+              "type": "string"
+            },
+            "consecutiveSamples": {
+              "description": "ConsecutiveSamples is the number of consecutive samples that must breach a threshold",
+              "format": "int32",
+              "minimum": 1,
+              "type": "integer"
+            },
+            "cooldown": {
+              "description": "Cooldown is the minimum time between resize actions for a pod\nexample values: 1m, 2m30s, 5m",
+              "format": "duration",
+              "minLength": 1,
+              "type": "string"
+            },
+            "cpu": {
+              "description": "CPU defines thresholds and target utilization for CPU",
+              "properties": {
+                "limits": {
+                  "description": "Limits defines utilization policy against container resource limits.\nIf omitted, PRA does not scale this resource's limits side.",
+                  "properties": {
+                    "consecutiveSamples": {
+                      "description": "ConsecutiveSamples optionally overrides policy.consecutiveSamples for this resource",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "cooldown": {
+                      "description": "Cooldown optionally overrides policy.cooldown for this resource\nexample values: 30s, 1m, 2m30s",
+                      "format": "duration",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "scaleDownThreshold": {
+                      "description": "ScaleDownThreshold triggers scale-down if utilization is <= this value (percent)",
+                      "format": "int32",
+                      "maximum": 100,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "scaleUpThreshold": {
+                      "description": "ScaleUpThreshold triggers scale-up if utilization is >= this value (percent)",
+                      "format": "int32",
+                      "maximum": 100,
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    "targetUtilization": {
+                      "description": "TargetUtilization is the desired utilization after resize (percent)",
+                      "format": "int32",
+                      "maximum": 100,
+                      "minimum": 1,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "scaleDownThreshold",
+                    "scaleUpThreshold",
+                    "targetUtilization"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "scaleUpThreshold must be greater than scaleDownThreshold",
+                      "rule": "self.scaleUpThreshold > self.scaleDownThreshold"
+                    },
+                    {
+                      "message": "consecutiveSamples override must be >= 1",
+                      "rule": "!has(self.consecutiveSamples) || self.consecutiveSamples >= 1"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "requests": {
+                  "description": "Requests defines utilization policy against container resource requests.\nIf omitted, PRA does not scale this resource's requests side.",
+                  "properties": {
+                    "consecutiveSamples": {
+                      "description": "ConsecutiveSamples optionally overrides policy.consecutiveSamples for this resource",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "cooldown": {
+                      "description": "Cooldown optionally overrides policy.cooldown for this resource\nexample values: 30s, 1m, 2m30s",
+                      "format": "duration",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "scaleDownThreshold": {
+                      "description": "ScaleDownThreshold triggers scale-down if utilization is <= this value (percent)",
+                      "format": "int32",
+                      "maximum": 100,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "scaleUpThreshold": {
+                      "description": "ScaleUpThreshold triggers scale-up if utilization is >= this value (percent)",
+                      "format": "int32",
+                      "maximum": 100,
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    "targetUtilization": {
+                      "description": "TargetUtilization is the desired utilization after resize (percent)",
+                      "format": "int32",
+                      "maximum": 100,
+                      "minimum": 1,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "scaleDownThreshold",
+                    "scaleUpThreshold",
+                    "targetUtilization"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "scaleUpThreshold must be greater than scaleDownThreshold",
+                      "rule": "self.scaleUpThreshold > self.scaleDownThreshold"
+                    },
+                    {
+                      "message": "consecutiveSamples override must be >= 1",
+                      "rule": "!has(self.consecutiveSamples) || self.consecutiveSamples >= 1"
+                    }
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "Specify requests and/or limits policy",
+                  "rule": "has(self.requests) || has(self.limits)"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "delay": {
+              "default": "15s",
+              "description": "Delay is the wait duration after `after` becomes true before a resize is applied\nexample values: 15s, 30s, 1m, 2m30s",
+              "format": "duration",
+              "minLength": 1,
+              "type": "string"
+            },
+            "memory": {
+              "description": "Memory defines thresholds and target utilization for memory",
+              "properties": {
+                "limits": {
+                  "description": "Limits defines utilization policy against container resource limits.\nIf omitted, PRA does not scale this resource's limits side.",
+                  "properties": {
+                    "consecutiveSamples": {
+                      "description": "ConsecutiveSamples optionally overrides policy.consecutiveSamples for this resource",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "cooldown": {
+                      "description": "Cooldown optionally overrides policy.cooldown for this resource\nexample values: 30s, 1m, 2m30s",
+                      "format": "duration",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "scaleDownThreshold": {
+                      "description": "ScaleDownThreshold triggers scale-down if utilization is <= this value (percent)",
+                      "format": "int32",
+                      "maximum": 100,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "scaleUpThreshold": {
+                      "description": "ScaleUpThreshold triggers scale-up if utilization is >= this value (percent)",
+                      "format": "int32",
+                      "maximum": 100,
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    "targetUtilization": {
+                      "description": "TargetUtilization is the desired utilization after resize (percent)",
+                      "format": "int32",
+                      "maximum": 100,
+                      "minimum": 1,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "scaleDownThreshold",
+                    "scaleUpThreshold",
+                    "targetUtilization"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "scaleUpThreshold must be greater than scaleDownThreshold",
+                      "rule": "self.scaleUpThreshold > self.scaleDownThreshold"
+                    },
+                    {
+                      "message": "consecutiveSamples override must be >= 1",
+                      "rule": "!has(self.consecutiveSamples) || self.consecutiveSamples >= 1"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "requests": {
+                  "description": "Requests defines utilization policy against container resource requests.\nIf omitted, PRA does not scale this resource's requests side.",
+                  "properties": {
+                    "consecutiveSamples": {
+                      "description": "ConsecutiveSamples optionally overrides policy.consecutiveSamples for this resource",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "cooldown": {
+                      "description": "Cooldown optionally overrides policy.cooldown for this resource\nexample values: 30s, 1m, 2m30s",
+                      "format": "duration",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "scaleDownThreshold": {
+                      "description": "ScaleDownThreshold triggers scale-down if utilization is <= this value (percent)",
+                      "format": "int32",
+                      "maximum": 100,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "scaleUpThreshold": {
+                      "description": "ScaleUpThreshold triggers scale-up if utilization is >= this value (percent)",
+                      "format": "int32",
+                      "maximum": 100,
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    "targetUtilization": {
+                      "description": "TargetUtilization is the desired utilization after resize (percent)",
+                      "format": "int32",
+                      "maximum": 100,
+                      "minimum": 1,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "scaleDownThreshold",
+                    "scaleUpThreshold",
+                    "targetUtilization"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "scaleUpThreshold must be greater than scaleDownThreshold",
+                      "rule": "self.scaleUpThreshold > self.scaleDownThreshold"
+                    },
+                    {
+                      "message": "consecutiveSamples override must be >= 1",
+                      "rule": "!has(self.consecutiveSamples) || self.consecutiveSamples >= 1"
+                    }
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "Specify requests and/or limits policy",
+                  "rule": "has(self.requests) || has(self.limits)"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "pollInterval": {
+              "description": "PollInterval is how often kubelet stats are polled per node\nexample values: 5s, 10s, 30s, 1m",
+              "format": "duration",
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "consecutiveSamples",
+            "cooldown",
+            "pollInterval"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "priority": {
+          "default": 0,
+          "description": "Priority in case multiple (unpaused) PodResourceAutoscaler CRs matches, only the one with\nthe highest priority will be applied. If not specified, it is 0 and if multiple\nPodResourceAutoscaler with the same priority matches the pod's label selector, then\nthe next one that's closest to now() is chosen. Again if multiple match, then\nlexicographically smaller is picked (CR name).",
+          "type": "integer"
+        },
+        "selector": {
+          "description": "Selector is the general label selector spec that identifies one or multiple Pods\nif selector is specified, don't use the target",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "target": {
+          "description": "Target is the reference to a workload whose pods should be modified\nif target is specified, don't use the selector",
+          "properties": {
+            "kind": {
+              "description": "Kind specifies the target workload whose containers will be obtaining the resource updates",
+              "enum": [
+                "deployment",
+                "daemonset",
+                "statefulset"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "containerName",
+        "policy"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "PodResourceAutoscaler must have either a pod selector or target specified",
+          "rule": "has(self.target) != has(self.selector)"
+        },
+        {
+          "message": "Specify at least one of policy.cpu.requests, policy.cpu.limits, policy.memory.requests, policy.memory.limits",
+          "rule": "(has(self.policy.cpu) && (has(self.policy.cpu.requests) || has(self.policy.cpu.limits))) || (has(self.policy.memory) && (has(self.policy.memory.requests) || has(self.policy.memory.limits)))"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "PodResourceAutoscalerStatus defines the observed state of PodResourceAutoscaler",
+      "properties": {
+        "conditions": {
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "effectiveSelector": {
+          "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "lastScaleAction": {
+          "type": "string"
+        },
+        "lastScaleResourceChange": {
+          "description": "LastScaleResourceChange summarizes request/limit changes from the last scale action.",
+          "type": "string"
+        },
+        "lastScaleTime": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "scaling": {
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/crd-schemas/podresourceprofile_v1alpha1.json
+++ b/crd-schemas/podresourceprofile_v1alpha1.json
@@ -1,0 +1,375 @@
+{
+  "description": "PodResourceProfile is the Schema for the PodResourceProfile API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "PodResourceProfileSpec defines the desired state of PodResourceProfile",
+      "properties": {
+        "containerName": {
+          "description": "ContainerName what container in the pod should be updated",
+          "minLength": 1,
+          "type": "string"
+        },
+        "newResources": {
+          "description": "NewResources contains the new resource settings that should be applied",
+          "properties": {
+            "limits": {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                "x-kubernetes-int-or-string": true
+              },
+              "type": "object"
+            },
+            "requests": {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                "x-kubernetes-int-or-string": true
+              },
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "Specify limits or requests or both",
+              "rule": "has(self.limits) || has(self.requests)"
+            }
+          ],
+          "additionalProperties": false
+        },
+        "newResourcesPercent": {
+          "description": "NewResourcesPercent contains signed percent deltas to apply to current resources",
+          "properties": {
+            "limits": {
+              "additionalProperties": {
+                "format": "int32",
+                "type": "integer"
+              },
+              "description": "ResourcePercentList maps resource name to signed percent delta.",
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "Only cpu and memory resources are supported",
+                  "rule": "self.all(k, k == 'cpu' || k == 'memory')"
+                },
+                {
+                  "message": "Percent value must be between -99 and 1000",
+                  "rule": "self.all(k, self[k] >= -99 && self[k] <= 1000)"
+                }
+              ]
+            },
+            "requests": {
+              "additionalProperties": {
+                "format": "int32",
+                "type": "integer"
+              },
+              "description": "ResourcePercentList maps resource name to signed percent delta.",
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "Only cpu and memory resources are supported",
+                  "rule": "self.all(k, k == 'cpu' || k == 'memory')"
+                },
+                {
+                  "message": "Percent value must be between -99 and 1000",
+                  "rule": "self.all(k, self[k] >= -99 && self[k] <= 1000)"
+                }
+              ]
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "Specify limits or requests or both",
+              "rule": "has(self.limits) || has(self.requests)"
+            }
+          ],
+          "additionalProperties": false
+        },
+        "paused": {
+          "default": false,
+          "description": "Paused if set to true, can make the controller ignore this CR",
+          "type": "boolean"
+        },
+        "priority": {
+          "default": 0,
+          "description": "Priority in case multiple (unpaused) PodResourceProfile CRs matches, only the one with\nthe highest priority will be applied. If not specified, it is 0 and if multiple\nPodResourceProfile with the same priority matches the pod's label selector, then\nthe next one that's closest to now() is chosen. Again if multiple match, then\nlexicographically smaller is picked (CR name).",
+          "type": "integer"
+        },
+        "selector": {
+          "description": "Selector is the general label selector spec that identifies one or multiple Pods\nif selector is specified, don't use the target",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "target": {
+          "description": "Target is the reference to a workload whose pods should be modified\nif target is specified, don't use the selector",
+          "properties": {
+            "kind": {
+              "description": "Kind specifies the target workload whose containers will be obtaining the resource updates\nCaveat: if set to 'scaledobject' the ScaledObject has to have its\n        '.spec.scaleTargetRef.kind' equal to 'deployment' or 'statefulset' so that\n        we can reach to its pods transitively.DeepCopy  In other words not every\n        scalable CR will work here. For MachindeDeployments this feature doesn't\n        make sense.",
+              "enum": [
+                "deployment",
+                "daemonset",
+                "statefulset",
+                "scaledobject"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "trigger": {
+          "description": "Trigger is condition or event that triggers the resource change",
+          "properties": {
+            "after": {
+              "default": "containerReady",
+              "description": "After specifies the event or the state pod/container needs to be in when we start counting (see Delay)\n\nAllowed values are:\n- 'containerReady': specifies whether the container is currently passing its\n  readiness check. The value will change as readiness probes keep executing.\n  If no readiness probes are specified, this field defaults to true once the\n  container is fully started.\n   field: pod.status.containerStatuses.ready\n    time: pod.status.containerStatuses.state.running.startedAt\n\n- 'containerStarted': indicates whether the container has finished its\n  postStart  lifecycle hook and passed its startup probe. Initialized as\n  false, becomes true after startupProbe is considered successful. Resets\n  to false when the container is restarted, or if kubelet loses state\n  temporarily. In both cases, startup probes will run again. Is always\n  true when no startupProbe is defined and container is running and has\n  passed the postStart lifecycle hook. The null value must be treated the\n  same as false.\n\t  field: pod.status.containerStatuses.started\n\t   time: pod.status.containerStatuses.state.running.startedAt\n\n- 'podReady': means the pod is able to service requests and should be added\n  to the load balancing pools of all matching services\n   field: pod.status.conditions[?(.type=='Ready')].status\n    time: pod.status.conditions[?(.type=='Ready')].lastTransitionTime\n\n- 'podScheduled': represents status of the scheduling process for this pod\n   field: pod.status.conditions[?(.type=='PodScheduled')].status\n    time: pod.status.conditions[?(.type=='PodScheduled')].lastTransitionTime\n\n- 'podRunning' means the pod has been bound to a node and all the\n  containers have been started. At least one container is still running\n  or is in the process of being restarted.\n    field: pod.status.phase\n     time: pod.status.startTime.time\n\n- 'deactivated' This is specific to KEDA and works only with\n                .target.kind == scaledobject.\n  It denotes a state of a ScaledObject whose triggers are not active. This\n  is useful for throttling the CPU for a workloads that are not being\n  actively used - stand-by mode.\n    field: scaledobject.conditions[?(.type=='Active')].status\n     time: scaledobject.conditions[?(.type=='Active')].lastTransitionTime\n     when the aforementioned field goes from true (active) -> false (passive)\n\n- 'activated' Dual event to 'deactivated'.\n    field: scaledobject.conditions[?(.type=='Active')].status\n     time: time: scaledobject.conditions[?(.type=='Active')].lastTransitionTime\n     when the aforementioned field goes from true (passive) -> false (active)",
+              "enum": [
+                "containerReady",
+                "containerStarted",
+                "podReady",
+                "podScheduled",
+                "podRunning",
+                "deactivated",
+                "activated"
+              ],
+              "type": "string"
+            },
+            "delay": {
+              "description": "Delay denotes how long the controller should wait before applying the new resources to the pod\nexample values: 30s, 1m, 2m30s, 90s, 2h",
+              "format": "duration",
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "delay"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "containerName",
+        "trigger"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "PodResourceProfile must have either a pod selector or target specified",
+          "rule": "has(self.target) != has(self.selector)"
+        },
+        {
+          "message": "'(de)activated' triggers can be used only with ScaledObjects as targets. See .spec.target.kind",
+          "rule": "!has(self.trigger.after) || !self.trigger.after.endsWith('activated') || (has(self.target) && self.target.kind == 'scaledobject' && self.trigger.after.endsWith('activated'))"
+        },
+        {
+          "message": "Specify exactly one of newResources or newResourcesPercent",
+          "rule": "has(self.newResources) != has(self.newResourcesPercent)"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "PodResourceProfileStatus defines the observed state of PodResourceProfile",
+      "properties": {
+        "conditions": {
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "effectiveSelector": {
+          "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "lastResourceUpdate": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "triggered": {
+          "type": "boolean"
+        },
+        "triggeredAt": {
+          "format": "date-time",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/crd-schemas/scalingpolicy_v1alpha1.json
+++ b/crd-schemas/scalingpolicy_v1alpha1.json
@@ -1,0 +1,337 @@
+{
+  "description": "ScalingPolicy is the Schema for the scalingpolicies API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ScalingPolicySpec defines the desired state of ScalingPolicy",
+      "properties": {
+        "actions": {
+          "description": "Action is the list of actions to be taken",
+          "items": {
+            "description": "ScalingAction defines the action to be taken",
+            "properties": {
+              "adjustment": {
+                "description": "ActionAdjustment defines the adjustment for the action",
+                "properties": {
+                  "idleReplicaCount": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "maxReplicaCount": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "minReplicaCount": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "pauseConfig": {
+                    "description": "PauseConfig defines the pause configuration",
+                    "properties": {
+                      "paused": {
+                        "description": "Paused is the flag to pause the scaling policy\nautoscaling.keda.sh/paused",
+                        "type": "boolean"
+                      },
+                      "replicas": {
+                        "description": "Replicas is the number of replicas to be set when the scaling policy is paused\nautoscaling.keda.sh/paused-replicas",
+                        "format": "int32",
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "pollingInterval": {
+                    "format": "int32",
+                    "type": "integer"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "name": {
+                "type": "string"
+              },
+              "priority": {
+                "format": "int32",
+                "type": "integer"
+              },
+              "trigger": {
+                "description": "ActionTrigger defines the trigger for the action",
+                "properties": {
+                  "schedule": {
+                    "description": "ActionTriggerSchedule defines the schedule for the trigger",
+                    "properties": {
+                      "end": {
+                        "type": "string"
+                      },
+                      "start": {
+                        "type": "string"
+                      },
+                      "timezone": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "end",
+                      "start",
+                      "timezone"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "schedule"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "adjustment",
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "targets": {
+          "description": "Targets is the list target resources to be modified",
+          "items": {
+            "description": "ScalingActionTarget defines the target resource to be modified",
+            "properties": {
+              "apiVersion": {
+                "type": "string"
+              },
+              "kind": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "actions",
+        "targets"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "ScalingPolicyStatus defines the observed state of ScalingPolicy",
+      "properties": {
+        "actions": {
+          "items": {
+            "description": "ScalingPolicyStatusAction defines the status of the action",
+            "properties": {
+              "active": {
+                "type": "boolean"
+              },
+              "applied": {
+                "type": "boolean"
+              },
+              "message": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "scheduleEnd": {
+                "format": "date-time",
+                "type": "string"
+              },
+              "scheduleStart": {
+                "format": "date-time",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "active": {
+          "type": "boolean"
+        },
+        "conditions": {
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "schedule": {
+          "description": "ScheduleStatus defines the status of the schedule",
+          "properties": {
+            "lastEnd": {
+              "format": "date-time",
+              "type": "string"
+            },
+            "lastStart": {
+              "format": "date-time",
+              "type": "string"
+            },
+            "nextEnd": {
+              "format": "date-time",
+              "type": "string"
+            },
+            "nextSchedule": {
+              "format": "date-time",
+              "type": "string"
+            },
+            "nextStart": {
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "targets": {
+          "additionalProperties": {
+            "description": "ScalingPolicyStatusTarget defines the status of the target",
+            "properties": {
+              "message": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "namespace": {
+                "type": "string"
+              },
+              "originalConfig": {
+                "description": "ActionAdjustment defines the adjustment for the action",
+                "properties": {
+                  "idleReplicaCount": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "maxReplicaCount": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "minReplicaCount": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "pauseConfig": {
+                    "description": "PauseConfig defines the pause configuration",
+                    "properties": {
+                      "paused": {
+                        "description": "Paused is the flag to pause the scaling policy\nautoscaling.keda.sh/paused",
+                        "type": "boolean"
+                      },
+                      "replicas": {
+                        "description": "Replicas is the number of replicas to be set when the scaling policy is paused\nautoscaling.keda.sh/paused-replicas",
+                        "format": "int32",
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "pollingInterval": {
+                    "format": "int32",
+                    "type": "integer"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "reason": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "status"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "object"
+        },
+        "validatedGeneration": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
then it can be used as:

```
λ kubeconform -schema-location crd-schemas/podresourceprofile_v1alpha1.json -summary -output json ../agent/config/samples/keda_v1alpha1_podresourceprofile.yaml
{
  "resources": [],
  "summary": {
    "valid": 1,
    "invalid": 0,
    "errors": 0,
    "skipped": 0
  }
}
```

the command can also accept an url or even a scheme where crd name and version are path of the url, like in [here](https://github.com/yannh/kubeconform#customresourcedefinition-crd-support):
```
-schema-location default -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
```
notes:
- the conversion script stolen from https://github.com/yannh/kubeconform/blob/master/scripts/openapi2jsonschema.py (but it was stolen originally from somewhere else, so I left the initial origin in the comment)
- no AI has been used (probably a bad idea :D)