### PR TITLE
Trigger openshift operator release

### DIFF
--- a/.github/workflows/gh-release-chart.yml
+++ b/.github/workflows/gh-release-chart.yml
@@ -147,6 +147,17 @@ jobs:
         run: |
           set -euo pipefail
           gh release upload "${{ steps.push_tag.outputs.new_tag }}" ./artifacts/generated-images.json --repo kedify/charts --clobber
+      - name: Trigger Openshift Operator release
+        if: inputs.chart == 'kedify-agent'
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+        run: |
+          set -euo pipefail
+          chart_version="${{ steps.version.outputs.newVersion }}"
+          operator_input_version="${chart_version#v}"
+          gh workflow run release.yaml \
+            --repo kedify/kedify-agent-helm-operator \
+            -f version="${operator_input_version}"
       - name: Create k3s cluster
         if: inputs.chart == 'keda' || inputs.chart == 'kedify-agent'
         uses: AbsaOSS/k3d-action@v2

--- a/.github/workflows/gh-release-chart.yml
+++ b/.github/workflows/gh-release-chart.yml
@@ -147,17 +147,6 @@ jobs:
         run: |
           set -euo pipefail
           gh release upload "${{ steps.push_tag.outputs.new_tag }}" ./artifacts/generated-images.json --repo kedify/charts --clobber
-      - name: Trigger Openshift Operator release
-        if: inputs.chart == 'kedify-agent'
-        env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
-        run: |
-          set -euo pipefail
-          chart_version="${{ steps.version.outputs.newVersion }}"
-          operator_input_version="${chart_version#v}"
-          gh workflow run release.yaml \
-            --repo kedify/kedify-agent-helm-operator \
-            -f version="${operator_input_version}"
       - name: Create k3s cluster
         if: inputs.chart == 'keda' || inputs.chart == 'kedify-agent'
         uses: AbsaOSS/k3d-action@v2
@@ -249,3 +238,14 @@ jobs:
           echo "::group::resulting YAML manifests"
           helm get manifest -n keda agent
           echo "::endgroup::"
+      - name: Trigger Openshift Operator release
+        if: inputs.chart == 'kedify-agent'
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+        run: |
+          set -euo pipefail
+          chart_version="${{ steps.version.outputs.newVersion }}"
+          operator_input_version="${chart_version#v}"
+          gh workflow run release.yaml \
+            --repo kedify/kedify-agent-helm-operator \
+            -f version="${operator_input_version}"


### PR DESCRIPTION
Openshift Operator release opens 2 pull requests. Both need to be reviewed by Kedify:
* downstream: https://github.com/kedify/kedify-agent-helm-operator (we need to merge it)
* upstream: https://github.com/redhat-openshift-ecosystem/certified-operators (we need to pass tests)