### PR TITLE
rbac: support for events.k8s.io

### DIFF
--- a/kedify-agent/templates/agent-rbac.yaml
+++ b/kedify-agent/templates/agent-rbac.yaml
@@ -217,6 +217,16 @@ rules:
   - list
   - watch
 - apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - events


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

Moving from core `events` to `events.k8s.io` after bumping k8s 0.35 


Relates: https://github.com/kedify/agent/pull/568
