### PR TITLE
ci add id token to release pipeline

### DIFF
--- a/.github/workflows/milestones-tracker-keda.yaml
+++ b/.github/workflows/milestones-tracker-keda.yaml
@@ -15,6 +15,7 @@ jobs:
       pull-requests: write
       issues: write
       packages: write
+      id-token: write
 
     uses: ./.github/workflows/milestones-tracker.yaml
     with:


### PR DESCRIPTION
otherwise release pipeline is broken
https://github.com/kedify/charts/actions/runs/27200206417
```
Invalid workflow file: .github/workflows/milestones-tracker-keda.yaml#L19
The workflow is not valid. .github/workflows/milestones-tracker-keda.yaml (Line: 19, Col: 11): Secret AWS_GITHUB_ROLE_ARN is required, but not provided while calling. .github/workflows/milestones-tracker-keda.yaml (Line: 10, Col: 3): Error calling workflow 'kedify/charts/.github/workflows/milestones-tracker.yaml@4c3b553b0fe80f7095094908749616686bae3830'. The nested job 'eks_addon_release' is requesting 'id-token: write', but is only allowed 'id-token: none'.
```