### PR TITLE
Expose metrics from kedify agent using k8s service

### DIFF
--- a/kedify-agent/templates/agent-deployment.yaml
+++ b/kedify-agent/templates/agent-deployment.yaml
@@ -145,6 +145,10 @@ spec:
               value: {{ .Values.agent.autowire.ingressCooldownPeriod | quote }}
           image: "{{ .Values.agent.image.repository }}:{{ .Values.agent.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
+          ports:
+            - name: metrics
+              containerPort: 8080
+              protocol: TCP
           livenessProbe:
             httpGet:
               path: /healthz

--- a/kedify-agent/templates/agent-service.yaml
+++ b/kedify-agent/templates/agent-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: manager
+    control-plane: kedify-agent
+    {{- include "kedify-agent.labels" . | nindent 4 }}
+  name: kedify-agent-metrics
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+    - name: metrics
+      port: 8080
+      targetPort: metrics
+      protocol: TCP
+  selector:
+    control-plane: kedify-agent


### PR DESCRIPTION
for exposing them on localhost:
```
k port-forward svc/kedify-agent-metrics -nkeda 8080
```

for quick "snapshot":
```
k run -it -nkeda --image=badouralix/curl-jq:alpine --rm --restart=Never --command metrics -- curl http://kedify-agent-metrics:8080/metrics
```