### PR TITLE
Add kedify-observability as an optional sub-chart (disabled by default)

### DIFF
--- a/kedify-agent/Chart.lock
+++ b/kedify-agent/Chart.lock
@@ -14,5 +14,8 @@ dependencies:
 - name: autoscaling-checks
   repository: oci://ghcr.io/kedify/charts
   version: 0.0.2
-digest: sha256:ac4907f758a3f3cbf082c1ad3ea9292e724b01bc738f86292be97346c9d8509e
-generated: "2026-07-14T17:20:59.48966+02:00"
+- name: kedify-observability
+  repository: oci://ghcr.io/kedify/charts
+  version: 0.0.3
+digest: sha256:aab9e123996448f7fb9752b8670916f7e5dc94ae319c59795b796e31d60f7702
+generated: "2026-07-15T15:21:19.512204+02:00"

--- a/kedify-agent/Chart.yaml
+++ b/kedify-agent/Chart.yaml
@@ -27,6 +27,10 @@ dependencies:
     repository: oci://ghcr.io/kedify/charts
     version: 0.0.2
     condition: autoscalingChecks.enabled,autoscaling-checks.enabled
+  - name: kedify-observability
+    repository: oci://ghcr.io/kedify/charts
+    version: 0.0.3
+    condition: kedifyObservability.enabled,kedify-observability.enabled
 home: https://github.com/kedify/charts
 sources:
   - https://github.com/kedify/agent

--- a/kedify-agent/README.md
+++ b/kedify-agent/README.md
@@ -20,6 +20,7 @@ Kubernetes: `>=v1.23.0-0`
 | https://kedify.github.io/charts | keda | v2.20.1-4 |
 | https://kedify.github.io/charts | keda-add-ons-http | v0.11.1-5 |
 | oci://ghcr.io/kedify/charts | autoscaling-checks | 0.0.2 |
+| oci://ghcr.io/kedify/charts | kedify-observability | 0.0.3 |
 | oci://ghcr.io/kedify/charts | kedify-predictor | 0.1.4 |
 | oci://ghcr.io/kedify/charts | otel-add-on | 0.1.4 |
 

--- a/kedify-agent/templates/NOTES.txt
+++ b/kedify-agent/templates/NOTES.txt
@@ -27,4 +27,6 @@ You have successfully installed the:
 {{- end}}
 {{- if (or ((.Values.autoscalingChecks).enabled) (and (index .Values "autoscaling-checks") (index .Values "autoscaling-checks").enabled)) }}
  - autoscaling-checks
+{{- if (or ((.Values.kedifyObservability).enabled) (and (index .Values "kedify-observability") (index .Values "kedify-observability").enabled)) }}
+ - kedify-observability (kubectl port-forward -nobs svc/grafana 3000:80)
 {{- end}}

--- a/kedify-agent/values.yaml
+++ b/kedify-agent/values.yaml
@@ -264,23 +264,27 @@ keda:
       enabled: true
     webhooks:
       enabled: true
+
 keda-add-ons-http:
   # for all available values, check: https://github.com/kedify/charts/blob/main/http-add-on/values.yaml
   enabled: false
   interceptor:
     scaledObject:
       waitForCrd: true
+
 otel-add-on:
   # for all available values, check: https://github.com/kedify/otel-add-on/blob/main/helmchart/otel-add-on/values.yaml
   enabled: false
   fullnameOverride: kedify-otel-scaler
   otelOperator:
     enabled: true
+
 kedify-predictor:
   # for all available values:
   # helm show values oci://ghcr.io/kedify/charts/kedify-predictor
   enabled: false
   fullnameOverride: kedify-predictor
+
 autoscaling-checks:
   # Optionally install set of small check runner apps that validate KEDA/Kedify autoscaling end to end
   # each check is a small web service that can be scaled up and down by KEDA/Kedify based on the configured triggers
@@ -299,3 +303,9 @@ autoscaling-checks:
     enabled: true
   memory:
     enabled: false
+
+kedify-observability:
+  # Optionally install the opinionated observability stack for Kedify.
+  # For all available values, check https://github.com/kedify/charts/blob/main/kedify-observability/values.yaml
+  enabled: false
+


### PR DESCRIPTION
This brings in a lot of dependent charts

```
 ── kedify-observability 0.0.3
      ├── grafana 10.5.15
      │
      ├── prometheus 29.13.1
      │   ├── alertmanager 1.40.0
      │   ├── kube-state-metrics 7.5.1
      │   ├── prometheus-node-exporter 4.55.0
      │   └── prometheus-pushgateway 3.6.1
      │
      ├── loki 18.3.0
      │   ├── minio 5.4.0
      │   └── rollout-operator 0.50.0
      │       ├── alias: rollout_operator
      │       └── crds 0.1.0
      │
      └── opentelemetry-collector 0.159.2
          └── alias: collector
```

however, it's disabled by default and by default the enablement looks like this:

```
 ── kedify-observability (✗)
      ├── grafana (✓)
      │
      ├── prometheus (✓)
      │   ├── alertmanager (✗)
      │   ├── kube-state-metrics (✓)
      │   ├── prometheus-node-exporter (✗)
      │   └── prometheus-pushgateway (✗)
      │
      ├── loki (✓)
      │   ├── minio (✓)
      │   └── rollout-operator (✗)
      │
      └── opentelemetry-collector (✓)
```

Then if user doesn't want to use Prometheus & Loki for instance but has it's own grafana and is interested only in dashboards.. one can disable the components further by something like

```
...
kedify-observability:
  enabled: true
  dashboards:
    enabled: true
  grafana:
    enabled: false
  prometheus:
     enabled: false
  loki:
     enabled: false
  collector:
    enabled: false
```
full values [here](https://github.com/kedify/charts/blob/main/kedify-observability/values.yaml)

Some dashboards will not be 100% operational though (if disabling ^), because they consume some metrics from specially [configured](https://github.com/kedify/charts/blob/aa0575271681f3350b91549330c1bf8a660c62ce/kedify-observability/values.yaml#L586-L1631) KSM about our CRDs.

Last but not least, one can disable everything and use this only for creating some noise for Kedify Agent and Keda:
the CRDs have knobs on the helm chart level like how many of them. Basically helm chart version of this https://github.com/kedify/examples/tree/main/test-data

example:

```
...
kedify-observability:
  enabled: true
  dashboards:
    enabled: false
  grafana:
    enabled: false
  prometheus:
     enabled: false
  loki:
     enabled: false
  collector:
    enabled: false

  optionalResources:
    all:
      # when enabled, it installs all the bellow resources (except metricPredictor)
      enabled: false

    scaledObjectsAndJobsCommon:
      namespaceCount: 2
      namespacePrefix: obs
      minuteMetricsSchedule: "0:2,1:0,2:3,3:2,4:0,5:1,7:2,8:5,9:0"
      # use either this or the minuteMetricsSchedule above, not both (randomMinuteMetricsSchedule will override minuteMetricsSchedule)
      randomMinuteMetricsSchedule: false
  
    scaledObjects:
      enabled: false
      unpausedPerNamespace: 3
      pausedPerNamespace: 1
  
    scaledJobs:
      enabled: false
      unpausedPerNamespace: 1
      pausedPerNamespace: 1
      sleepSeconds: 30
    
    clusterTriggerAuthentications:
      enabled: false
  
    triggerAuthentications:
      enabled: false
  
    metricPredictor:
      enabled: false
  
    pra:
      enabled: false
  
    prp:
      enabled: false
      initialMemoryRequest: 50M
      updateMemoryRequest: 30M
      delay: 30s
  
    scalingPolicy:
      enabled: false
  
    scalingGroup:
      enabled: false
```