### PR TITLE
Missing Agent's RBAC for nodes (watch) got removed by accident

### DIFF
--- a/kedify-agent/templates/agent-rbac.yaml
+++ b/kedify-agent/templates/agent-rbac.yaml
@@ -275,6 +275,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 {{- end }}
 {{- if .Values.agent.rbac.readPods }}
 - apiGroups:


### PR DESCRIPTION
Fix
```
controller-runtime.cache.UnhandledError	Failed to watch	{"reflector": "k8s.io/client-go@v1.5.2/tools/cache/reflector.go:289", "type": "*v1.Node", "error": "nodes is forbidden: User \"system:serviceaccount:keda:kedify-agent\" cannot watch resource \"nodes\" in API group \"\" at the cluster scope"}
```

(got [removed](https://github.com/kedify/charts/compare/kedify-agent/v0.6.4...kedify:charts:kedify-agent/v0.6.5#diff-0fd8cbb11b439dac98bc1b97e969929419b30f21dcb36f3dff7ba2d39f4424edL278) here)