### PR TITLE
Make sure kedify-observability chart respect the release namespace

### DIFF
--- a/kedify-observability/templates/NOTES.txt
+++ b/kedify-observability/templates/NOTES.txt
@@ -34,6 +34,6 @@
                     +--------------------------------------------+
 
 continue with:
-kubectl port-forward -nobs svc/grafana 3000:80
+kubectl port-forward -n{{ .Release.Namespace }} svc/grafana 3000:80
 open http://localhost:3000/dashboards
 

--- a/kedify-observability/templates/optional/mp.yaml
+++ b/kedify-observability/templates/optional/mp.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-mm
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.optionalResources.namespaceOverride | default .Release.Namespace }}
 spec:
   replicas: 1
   selector:
@@ -35,7 +35,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-mm
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.optionalResources.namespaceOverride | default .Release.Namespace }}
 spec:
   selector:
     app: {{ .Release.Name }}-mm
@@ -51,7 +51,7 @@ apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
   name: {{ .Release.Name }}-mm
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.optionalResources.namespaceOverride | default .Release.Namespace }}
 spec:
   scaleTargetRef:
     name: {{ .Release.Name }}-demo
@@ -88,7 +88,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-demo
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.optionalResources.namespaceOverride | default .Release.Namespace }}
 spec:
   replicas: 1
   selector:
@@ -126,7 +126,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-demo
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.optionalResources.namespaceOverride | default .Release.Namespace }}
 spec:
   type: NodePort
   ports:
@@ -140,7 +140,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-config
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.optionalResources.namespaceOverride | default .Release.Namespace }}
 data:
   nginx.conf: |
     server {
@@ -161,7 +161,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-index-html
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.optionalResources.namespaceOverride | default .Release.Namespace }}
 data:
   index.html: |
     <html>
@@ -186,7 +186,7 @@ apiVersion: keda.kedify.io/v1alpha1
 kind: MetricPredictor
 metadata:
   name: {{ .Release.Name }}-mm-in-ten
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.optionalResources.namespaceOverride | default .Release.Namespace }}
 spec:
   source:
     keda:

--- a/kedify-observability/templates/optional/pra.yaml
+++ b/kedify-observability/templates/optional/pra.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-heavy-pra
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.optionalResources.namespaceOverride | default .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-heavy-pra
 spec:
@@ -54,7 +54,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-heavy-pra
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.optionalResources.namespaceOverride | default .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-heavy-pra
 spec:
@@ -70,7 +70,7 @@ apiVersion: keda.kedify.io/v1alpha1
 kind: PodResourceAutoscaler
 metadata:
   name: {{ .Release.Name }}-heavy-pra
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.optionalResources.namespaceOverride | default .Release.Namespace }}
 spec:
   target:
     kind: deployment

--- a/kedify-observability/templates/optional/prp.yaml
+++ b/kedify-observability/templates/optional/prp.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-nginx-prp
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.optionalResources.namespaceOverride | default .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-nginx-prp
 spec:
@@ -31,7 +31,7 @@ apiVersion: keda.kedify.io/v1alpha1
 kind: PodResourceProfile
 metadata:
   name: {{ .Release.Name }}-nginx-prp
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.optionalResources.namespaceOverride | default .Release.Namespace }}
 spec:
   selector:
     matchLabels:

--- a/kedify-observability/templates/optional/sg.yaml
+++ b/kedify-observability/templates/optional/sg.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-app-1
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.optionalResources.namespaceOverride | default .Release.Namespace }}
 spec:
   replicas: 0
   selector:
@@ -26,7 +26,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-test-keda-metric-1
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.optionalResources.namespaceOverride | default .Release.Namespace }}
 spec:
   replicas: 1
   selector:
@@ -49,7 +49,7 @@ kind: ScaledObject
 apiVersion: keda.sh/v1alpha1
 metadata:
   name: {{ .Release.Name }}-app-1
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.optionalResources.namespaceOverride | default .Release.Namespace }}
   labels:
     scaling-group: cap-5
 spec:
@@ -76,7 +76,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-app-2
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.optionalResources.namespaceOverride | default .Release.Namespace }}
 spec:
   replicas: 0
   selector:
@@ -99,7 +99,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-test-keda-metric-2
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.optionalResources.namespaceOverride | default .Release.Namespace }}
 spec:
   replicas: 1
   selector:
@@ -122,7 +122,7 @@ kind: ScaledObject
 apiVersion: keda.sh/v1alpha1
 metadata:
   name: {{ .Release.Name }}-app-2
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.optionalResources.namespaceOverride | default .Release.Namespace }}
   labels:
     scaling-group: cap-5
 spec:
@@ -148,7 +148,7 @@ apiVersion: keda.kedify.io/v1alpha1
 kind: ScalingGroup
 metadata:
   name: {{ .Release.Name }}-max-group
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.optionalResources.namespaceOverride | default .Release.Namespace }}
 spec:
   capacity: 5
   selector:

--- a/kedify-observability/templates/optional/sos_sjs.yaml
+++ b/kedify-observability/templates/optional/sos_sjs.yaml
@@ -1,8 +1,8 @@
-
 {{- if or .Values.optionalResources.all.enabled (or .Values.optionalResources.scaledObjects.enabled .Values.optionalResources.scaledJobs.enabled) }}
 {{- range $i := until (.Values.optionalResources.scaledObjectsAndJobsCommon.namespaceCount | int) }}
 
 {{- $ns := printf "%s-%d" ($.Values.optionalResources.scaledObjectsAndJobsCommon.namespacePrefix | default $.Release.Name) $i }}
+---
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/kedify-observability/templates/optional/sp.yaml
+++ b/kedify-observability/templates/optional/sp.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-scaling-policy-metrics
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.optionalResources.namespaceOverride | default .Release.Namespace }}
 data:
   so-count: "8"
   sj-count: "12"
@@ -13,7 +13,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-scaling-policy-target
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.optionalResources.namespaceOverride | default .Release.Namespace }}
 spec:
   replicas: 1
   selector:
@@ -34,7 +34,7 @@ apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
   name: {{ .Release.Name }}-scaling-policy-so
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.optionalResources.namespaceOverride | default .Release.Namespace }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
@@ -58,7 +58,7 @@ apiVersion: keda.sh/v1alpha1
 kind: ScaledJob
 metadata:
   name: {{ .Release.Name }}-scaling-policy-sj
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.optionalResources.namespaceOverride | default .Release.Namespace }}
 spec:
   jobTargetRef:
     template:
@@ -90,7 +90,7 @@ apiVersion: keda.kedify.io/v1alpha1
 kind: ScalingPolicy
 metadata:
   name: {{ .Release.Name }}-scalingpolicy-sample
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.optionalResources.namespaceOverride | default .Release.Namespace }}
 spec:
   targets:
     - apiVersion: keda.sh/v1alpha1

--- a/kedify-observability/templates/optional/ta.yaml
+++ b/kedify-observability/templates/optional/ta.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: example-configmap
+  namespace: {{ .Values.optionalResources.namespaceOverride | default .Release.Namespace }}
 data:
   someKey: "randomValue12345"
 ---
@@ -12,6 +13,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: example-secret
+  namespace: {{ .Values.optionalResources.namespaceOverride | default .Release.Namespace }}
 type: Opaque
 data:
   someKey: cmFuZG9tVmFsdWU2Nzg5  # Base64 encoded "randomValue6789"
@@ -21,6 +23,7 @@ apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:
   name: trigger-auth-aws-pod-identity
+  namespace: {{ .Values.optionalResources.namespaceOverride | default .Release.Namespace }}
 spec:
   podIdentity:
     provider: aws
@@ -30,6 +33,7 @@ apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:
   name: trigger-auth-gcp-pod-identity
+  namespace: {{ .Values.optionalResources.namespaceOverride | default .Release.Namespace }}
 spec:
   podIdentity:
     provider: gcp
@@ -39,6 +43,7 @@ apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:
   name: trigger-auth-azure-workload-pod-identity
+  namespace: {{ .Values.optionalResources.namespaceOverride | default .Release.Namespace }}
 spec:
   podIdentity:
     provider: azure-workload
@@ -48,15 +53,11 @@ apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:
   name: trigger-auth-configmap
+  namespace: {{ .Values.optionalResources.namespaceOverride | default .Release.Namespace }}
 spec:
   configMapTargetRef:
   - parameter: someParameter
     name: example-configmap
-    key: someKey
-spec:
-  configMapTargetRef:
-  - parameter: someParameter
-    name: example-configmap-keda
     key: someKey
 ---
 # TriggerAuthentication with Secret
@@ -64,6 +65,7 @@ apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:
   name: trigger-auth-secret
+  namespace: {{ .Values.optionalResources.namespaceOverride | default .Release.Namespace }}
 spec:
   secretTargetRef:
   - parameter: someParameter
@@ -75,6 +77,7 @@ apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:
   name: trigger-auth-combined
+  namespace: {{ .Values.optionalResources.namespaceOverride | default .Release.Namespace }}
 spec:
   podIdentity:
     provider: aws
@@ -88,6 +91,7 @@ apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:
   name: trigger-auth-combined2
+  namespace: {{ .Values.optionalResources.namespaceOverride | default .Release.Namespace }}
 spec:
   podIdentity:
     provider: aws
@@ -105,6 +109,7 @@ apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:
   name: trigger-auth-all
+  namespace: {{ .Values.optionalResources.namespaceOverride | default .Release.Namespace }}
 spec:
   podIdentity:
     provider: aws

--- a/kedify-observability/values.yaml
+++ b/kedify-observability/values.yaml
@@ -2,6 +2,7 @@ optionalResources:
   all:
     enabled: false
 
+  namespaceOverride: ""
   scaledObjectsAndJobsCommon:
     namespaceCount: 2
     namespacePrefix: obs
@@ -54,7 +55,7 @@ dashboards:
 # ------------------------
 grafana:
   enabled: true
-  namespaceOverride: obs
+  namespaceOverride: ""
   fullnameOverride: grafana
   replicas: 1
   service:
@@ -83,7 +84,7 @@ grafana:
           uid: prometheus
           type: prometheus
           access: proxy
-          url: http://prometheus-server.obs.svc.cluster.local
+          url: http://prometheus-server
           isDefault: true
           editable: true
           jsonData:
@@ -92,7 +93,7 @@ grafana:
           uid: loki
           type: loki
           access: proxy
-          url: http://loki-gateway.obs.svc.cluster.local
+          url: http://loki-gateway
           editable: true
           
 
@@ -120,7 +121,7 @@ grafana:
 # ---------------------
 loki:
   enabled: true
-  namespaceOverride: obs
+  namespaceOverride: ""
   fullnameOverride: loki
   loki:
     auth_enabled: false
@@ -154,7 +155,7 @@ loki:
   minio:
     enabled: true
     fullnameOverride: minio
-    address: minio.obs.svc.cluster.local:9000
+    address: minio:9000
 
   deploymentMode: Monolithic
   singleBinary:
@@ -217,12 +218,11 @@ collector:
     - name: varlibdockercontainers
       mountPath: /var/lib/docker/containers
       readOnly: true
-  config:
+  alternateConfig:
+    extensions:
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
     receivers:
-      jaeger: null
-      prometheus: null
-      zipkin: null
-      otlp: null
       file_log/kedify_others:
         include:
           - /var/log/pods/keda_*/*/*.log
@@ -317,12 +317,10 @@ collector:
       batch: {}
     exporters:
       otlphttp/loki:
-        endpoint: http://loki-gateway.obs.svc.cluster.local/otlp
+        endpoint: http://loki-gateway/otlp
     service:
       extensions: [health_check]
       pipelines:
-        traces: null
-        metrics: null
         logs:
           receivers:
             - file_log/kedify_others
@@ -354,7 +352,7 @@ collector:
 # ---------------------------
 prometheus:
   enabled: true
-  forceNamespace: obs
+  forceNamespace: ""
   alertmanager:
     enabled: false
   prometheus-node-exporter:
@@ -497,7 +495,7 @@ prometheus:
       scrape_interval: 30s
       static_configs:
       - targets:
-        - kube-state-metrics.obs.svc.cluster.local:8080
+        - kube-state-metrics:8080
     kedify-predictor:
       metric_relabel_configs:
       - action: keep
@@ -508,7 +506,7 @@ prometheus:
       scrape_interval: 30s
       static_configs:
       - targets:
-        - kedify-predictor.keda.svc.cluster.local:8080
+        - kedify-predictor:8080
     kubernetes-api-servers:
       enabled: false
     kubernetes-nodes:
@@ -537,7 +535,7 @@ prometheus:
   kube-state-metrics:
     enabled: true
     fullnameOverride: kube-state-metrics
-    namespaceOverride: obs
+    namespaceOverride: ""
     metricLabelsAllowlist:
       - deployments=[app.kubernetes.io/instance,app.kubernetes.io/name,app.kubernetes.io/component,app.kubernetes.io/managed-by,component,autoscaling-checks.kedify.io/check,autoscaling-checks.kedify.io/role]
       - daemonsets=[app.kubernetes.io/instance,app.kubernetes.io/name,app.kubernetes.io/component,app.kubernetes.io/managed-by,component]


### PR DESCRIPTION
Don't assume the chart will be installed into `obs` namespace. This chart is also linked from `kedify-agent` helm chart, where the release namespace is usually `keda`.